### PR TITLE
Fix branch filter reset effect

### DIFF
--- a/src/components/warehouse/WarehouseManagement.tsx
+++ b/src/components/warehouse/WarehouseManagement.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Badge } from '../ui/badge'
@@ -92,14 +92,14 @@ export function WarehouseManagement() {
   }, [warehouses, searchQuery, filterOrg, filterBranch, filterStatus])
 
   // Reset branch filter when organization filter changes
-  useState(() => {
+  useEffect(() => {
     if (filterOrg && filterBranch) {
       const selectedBranch = activeBranches.find(b => b.id === filterBranch)
       if (!selectedBranch || selectedBranch.organizationId !== filterOrg) {
         setFilterBranch('')
       }
     }
-  })
+  }, [filterOrg, filterBranch, activeBranches])
 
   const handleCreate = () => {
     setEditingWarehouse(undefined)


### PR DESCRIPTION
## Summary
- replace the mistaken useState side effect in WarehouseManagement with a useEffect hook
- ensure the branch filter resets when the selected organization changes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca64f41c408325858fd417cd074a53
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix branch filter reset in `WarehouseManagement` by replacing `useState` side effect with `useEffect`.
> 
>   - **Behavior**:
>     - Replace `useState` side effect with `useEffect` in `WarehouseManagement` to reset branch filter when organization changes.
>     - Ensures branch filter clears if selected branch does not belong to the selected organization.
>   - **Testing**:
>     - Run `npm run build` to ensure no build errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tringuyen111%2Fproject_tri_inventory&utm_source=github&utm_medium=referral)<sup> for 2b88f88bfd93f8d29c05b92a1b948463cc9d1e49. You can [customize](https://app.ellipsis.dev/tringuyen111/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->