### PR TITLE
feat: add goods issue management and detail views

### DIFF
--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -174,11 +174,17 @@ export function MainContent() {
           </CardHeader>
           <CardContent>
             <div className="grid gap-2">
-              <button className="flex items-center justify-start space-x-2 p-3 text-left hover:bg-accent rounded-md transition-colors">
+              <button
+                onClick={() => window.location.hash = '#warehouse/goods-receipt'}
+                className="flex items-center justify-start space-x-2 p-3 text-left hover:bg-accent rounded-md transition-colors"
+              >
                 <Package className="h-4 w-4" />
                 <span>Create Goods Receipt</span>
               </button>
-              <button className="flex items-center justify-start space-x-2 p-3 text-left hover:bg-accent rounded-md transition-colors">
+              <button
+                onClick={() => window.location.hash = '#warehouse/goods-issue'}
+                className="flex items-center justify-start space-x-2 p-3 text-left hover:bg-accent rounded-md transition-colors"
+              >
                 <TrendingUp className="h-4 w-4" />
                 <span>Process Goods Issue</span>
               </button>

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -14,9 +14,11 @@ import { GoodsReceiptFormWrapper } from './goodsreceipt/GoodsReceiptFormWrapper'
 import { GoodsReceiptDetail } from './goodsreceipt/GoodsReceiptDetail'
 import { GoodsReceiptApproval } from './goodsreceipt/GoodsReceiptApproval'
 import { GoodsReceiptSubmit } from './goodsreceipt/GoodsReceiptSubmit'
+import { GoodsIssueManagement } from './goodsissue/GoodsIssueManagement'
+import { GoodsIssueDetail } from './goodsissue/GoodsIssueDetail'
 
-type RouteKey = 
-  | 'dashboard' 
+type RouteKey =
+  | 'dashboard'
   | 'organization'
   | 'branch'
   | 'warehouse'
@@ -32,6 +34,8 @@ type RouteKey =
   | 'goodsreceipt/view'
   | 'goodsreceipt/approve'
   | 'goodsreceipt/submit'
+  | 'goodsissue'
+  | 'goodsissue/view'
 
 interface RouterProps {
   currentRoute: RouteKey
@@ -75,10 +79,15 @@ export function Router({ currentRoute }: RouterProps) {
       />
     case 'goodsreceipt/submit':
       const submitReceiptId = localStorage.getItem('submittingReceiptId')
-      return <GoodsReceiptSubmit 
-        receiptId={submitReceiptId || ''} 
-        onBack={() => window.location.hash = '#warehouse/goods-receipt'} 
+      return <GoodsReceiptSubmit
+        receiptId={submitReceiptId || ''}
+        onBack={() => window.location.hash = '#warehouse/goods-receipt'}
       />
+    case 'goodsissue':
+      return <GoodsIssueManagement />
+    case 'goodsissue/view':
+      const viewIssueId = localStorage.getItem('viewingGoodsIssueId')
+      return <GoodsIssueDetail issueId={viewIssueId || undefined} />
     case 'dashboard':
     default:
       return <MainContent />
@@ -109,6 +118,8 @@ export const useRouter = () => {
         'warehouse/goods-receipt/view': 'goodsreceipt/view',
         'warehouse/goods-receipt/approve': 'goodsreceipt/approve',
         'warehouse/goods-receipt/submit': 'goodsreceipt/submit',
+        'warehouse/goods-issue': 'goodsissue',
+        'warehouse/goods-issue/view': 'goodsissue/view',
         'dashboards': 'dashboard'
       }
       
@@ -141,7 +152,9 @@ export const useRouter = () => {
       'goodsreceipt/edit': '#warehouse/goods-receipt/edit',
       'goodsreceipt/view': '#warehouse/goods-receipt/view',
       'goodsreceipt/approve': '#warehouse/goods-receipt/approve',
-      'goodsreceipt/submit': '#warehouse/goods-receipt/submit'
+      'goodsreceipt/submit': '#warehouse/goods-receipt/submit',
+      'goodsissue': '#warehouse/goods-issue',
+      'goodsissue/view': '#warehouse/goods-issue/view'
     }
     
     window.location.hash = routeMap[route]

--- a/src/components/goodsissue/GoodsIssueDetail.tsx
+++ b/src/components/goodsissue/GoodsIssueDetail.tsx
@@ -1,0 +1,634 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  ArrowLeft,
+  CheckCircle,
+  Clock,
+  FileText,
+  MapPin,
+  Package,
+  ShieldCheck,
+  UploadCloud,
+  User
+} from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
+import { Badge } from '../ui/badge'
+import { Button } from '../ui/button'
+import { Separator } from '../ui/separator'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table'
+import { useLanguage } from '../../contexts/LanguageContext'
+import { GoodsIssue, GoodsIssueLine } from '../../types/goodsIssue'
+import { getGoodsIssueById } from '../../data/mockGoodsIssueData'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription
+} from '../ui/dialog'
+
+const translations = {
+  en: {
+    title: 'Goods Issue Detail',
+    subtitle: 'Review picking result, track serial/lot allocation and approval history',
+    information: 'Goods Issue Information',
+    logistics: 'Logistics & Partner',
+    attachments: 'Attachments',
+    pickingResult: 'Picking Result by Model',
+    trackingDialogTitle: 'Tracking Details',
+    trackingDialogSubtitle: 'Selected serial/lot and actual picking log for this model',
+    issueNo: 'Goods Issue No',
+    issueType: 'Issue Type',
+    issueMethod: 'Issue Method',
+    createdBy: 'Created By',
+    createdAt: 'Created At',
+    submittedBy: 'Submitted By',
+    submittedAt: 'Submitted At',
+    approvedBy: 'Approved By',
+    approvedAt: 'Approved At',
+    expectedDate: 'Expected Issue Date',
+    sourceWarehouse: 'Source Warehouse',
+    destination: 'Destination / Partner',
+    address: 'Address',
+    remark: 'Remark',
+    statusHistory: 'Status History',
+    modelCode: 'Model Code',
+    modelName: 'Model Name',
+    tracking: 'Tracking Type',
+    uom: 'Unit',
+    qtyPlanned: 'Qty Planned',
+    qtyPicked: 'Qty Picked',
+    difference: 'Difference',
+    lineStatus: 'Line Status',
+    actions: 'Actions',
+    view: 'View',
+    totalPlanned: 'Total Planned',
+    totalPicked: 'Total Picked',
+    totalDifference: 'Total Difference',
+    noRemark: 'No remark provided',
+    noAttachments: 'No attachments uploaded',
+    attachmentName: 'File name',
+    attachmentUploadedBy: 'Uploaded by',
+    attachmentUploadedAt: 'Uploaded at',
+    serialNo: 'Serial Number',
+    lotNo: 'Lot No',
+    qty: 'Quantity',
+    pickedBy: 'Picked By',
+    pickedAt: 'Picked At',
+    location: 'Location',
+    note: 'Note',
+    back: 'Back to Goods Issue',
+    statusLabel: 'Status',
+    exportPdf: 'Export PDF',
+    approveAction: 'Approve',
+    receivedDate: 'Lot Received Date',
+    Draft: 'Draft',
+    Picking: 'Picking',
+    AdjustmentRequested: 'Adjustment Requested',
+    Submitted: 'Submitted',
+    Approved: 'Approved',
+    Completed: 'Completed',
+    Cancelled: 'Cancelled',
+    Pending: 'Pending',
+    Shortage: 'Shortage',
+    Serial: 'Serial',
+    Lot: 'Lot',
+    Model: 'Model',
+    None: 'None',
+    SO: 'Sales Order',
+    Transfer: 'Transfer',
+    ReturnToSupplier: 'Return to Supplier',
+    Adjustment: 'Adjustment',
+    Manual: 'Manual'
+  },
+  vn: {
+    title: 'Chi Tiết Phiếu Xuất Kho',
+    subtitle: 'Kiểm tra kết quả picking, theo dõi serial/lot và lịch sử phê duyệt',
+    information: 'Thông Tin Phiếu Xuất',
+    logistics: 'Thông Tin Logistics & Đối Tác',
+    attachments: 'Tài Liệu Đính Kèm',
+    pickingResult: 'Kết Quả Picking Theo Model',
+    trackingDialogTitle: 'Chi Tiết Tracking',
+    trackingDialogSubtitle: 'Serial/Lot đã chọn và lịch sử picking của model này',
+    issueNo: 'Số phiếu xuất',
+    issueType: 'Loại phiếu',
+    issueMethod: 'Phương thức xuất',
+    createdBy: 'Tạo bởi',
+    createdAt: 'Ngày tạo',
+    submittedBy: 'Người gửi duyệt',
+    submittedAt: 'Ngày gửi',
+    approvedBy: 'Phê duyệt bởi',
+    approvedAt: 'Ngày phê duyệt',
+    expectedDate: 'Ngày xuất dự kiến',
+    sourceWarehouse: 'Kho xuất',
+    destination: 'Kho nhận / Đối tác',
+    address: 'Địa chỉ',
+    remark: 'Ghi chú',
+    statusHistory: 'Lịch sử trạng thái',
+    modelCode: 'Mã model',
+    modelName: 'Tên model',
+    tracking: 'Tracking',
+    uom: 'Đơn vị',
+    qtyPlanned: 'SL kế hoạch',
+    qtyPicked: 'SL thực tế',
+    difference: 'Chênh lệch',
+    lineStatus: 'Trạng thái dòng',
+    actions: 'Thao tác',
+    view: 'Xem',
+    totalPlanned: 'Tổng kế hoạch',
+    totalPicked: 'Tổng thực tế',
+    totalDifference: 'Tổng chênh lệch',
+    noRemark: 'Không có ghi chú',
+    noAttachments: 'Không có tài liệu đính kèm',
+    attachmentName: 'Tên file',
+    attachmentUploadedBy: 'Người tải lên',
+    attachmentUploadedAt: 'Thời gian tải lên',
+    serialNo: 'Số serial',
+    lotNo: 'Số lot',
+    qty: 'Số lượng',
+    pickedBy: 'Người picking',
+    pickedAt: 'Thời gian',
+    location: 'Vị trí',
+    note: 'Ghi chú',
+    back: 'Quay lại danh sách',
+    statusLabel: 'Trạng thái',
+    exportPdf: 'Xuất PDF',
+    approveAction: 'Phê duyệt',
+    receivedDate: 'Ngày nhập lot',
+    Draft: 'Nháp',
+    Picking: 'Đang picking',
+    AdjustmentRequested: 'Yêu cầu điều chỉnh',
+    Submitted: 'Đã gửi',
+    Approved: 'Đã duyệt',
+    Completed: 'Hoàn tất',
+    Cancelled: 'Đã hủy',
+    Pending: 'Chờ xử lý',
+    Shortage: 'Thiếu hàng',
+    Serial: 'Serial',
+    Lot: 'Lot',
+    Model: 'Theo Model',
+    None: 'Không tracking',
+    SO: 'Đơn bán hàng',
+    Transfer: 'Chuyển kho',
+    ReturnToSupplier: 'Trả nhà cung cấp',
+    Adjustment: 'Điều chỉnh',
+    Manual: 'Thủ công'
+  }
+}
+
+const statusColors = {
+  Draft: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200',
+  Picking: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+  AdjustmentRequested: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+  Submitted: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200',
+  Approved: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200',
+  Completed: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+  Cancelled: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
+} as const
+
+interface GoodsIssueDetailProps {
+  issueId?: string
+}
+
+export function GoodsIssueDetail({ issueId }: GoodsIssueDetailProps) {
+  const { language } = useLanguage()
+  const t = translations[language]
+
+  const [issue, setIssue] = useState<GoodsIssue | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [selectedLine, setSelectedLine] = useState<GoodsIssueLine | null>(null)
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      if (issueId) {
+        const found = getGoodsIssueById(issueId)
+        setIssue(found || null)
+      }
+      setLoading(false)
+    }, 300)
+
+    return () => clearTimeout(timeout)
+  }, [issueId])
+
+  const summary = useMemo(() => {
+    if (!issue) return { planned: 0, picked: 0, difference: 0 }
+
+    const planned = issue.lines.reduce((acc, line) => acc + line.qty_planned, 0)
+    const picked = issue.lines.reduce((acc, line) => acc + line.qty_picked, 0)
+    return { planned, picked, difference: picked - planned }
+  }, [issue])
+
+  const handleBack = () => {
+    window.location.hash = '#warehouse/goods-issue'
+  }
+
+  const renderTrackingContent = (line: GoodsIssueLine) => {
+    if (line.tracking_type === 'Serial') {
+      return (
+        <div className="space-y-2">
+          {line.pickings.map(record => (
+            <div key={record.id} className="rounded-lg border p-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  <ShieldCheck className="h-4 w-4 text-primary" />
+                  <span>{t.serialNo}</span>
+                </div>
+                <Badge variant="outline">{record.serial_no}</Badge>
+              </div>
+              <Separator className="my-3" />
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <User className="h-4 w-4" />
+                  <span>
+                    {t.pickedBy}: {record.picked_by}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Clock className="h-4 w-4" />
+                  <span>
+                    {t.pickedAt}: {new Date(record.picked_at).toLocaleString(language === 'vn' ? 'vi-VN' : 'en-US')}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <MapPin className="h-4 w-4" />
+                  <span>
+                    {t.location}: {record.location_code || '-'}
+                  </span>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )
+    }
+
+    if (line.tracking_type === 'Lot') {
+      return (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>{t.lotNo}</TableHead>
+              <TableHead>{t.qty}</TableHead>
+              <TableHead>{t.pickedAt}</TableHead>
+              <TableHead>{t.pickedBy}</TableHead>
+              <TableHead>{t.location}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {line.pickings.map(record => (
+              <TableRow key={record.id}>
+                <TableCell>{record.lot_no}</TableCell>
+                <TableCell>{record.qty_picked}</TableCell>
+                <TableCell>
+                  <div className="flex flex-col">
+                    <span>{new Date(record.picked_at).toLocaleString(language === 'vn' ? 'vi-VN' : 'en-US')}</span>
+                    {record.received_date && (
+                      <span className="text-xs text-muted-foreground">
+                        {t.receivedDate}: {new Date(record.received_date).toLocaleDateString(language === 'vn' ? 'vi-VN' : 'en-US')}
+                      </span>
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell>{record.picked_by}</TableCell>
+                <TableCell>{record.location_code || '-'}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )
+    }
+
+    return (
+      <div className="space-y-4">
+        {line.pickings.map(record => (
+          <div key={record.id} className="rounded-lg border p-4">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Package className="h-4 w-4" />
+                <span>
+                  {t.qty}: {record.qty_picked}
+                </span>
+              </div>
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <User className="h-4 w-4" />
+                <span>
+                  {t.pickedBy}: {record.picked_by}
+                </span>
+              </div>
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Clock className="h-4 w-4" />
+                <span>
+                  {t.pickedAt}: {new Date(record.picked_at).toLocaleString(language === 'vn' ? 'vi-VN' : 'en-US')}
+                </span>
+              </div>
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <MapPin className="h-4 w-4" />
+                <span>
+                  {t.location}: {record.location_code || '-'}
+                </span>
+              </div>
+            </div>
+            {record.note && (
+              <p className="mt-3 text-sm italic text-muted-foreground">
+                {t.note}: {record.note}
+              </p>
+            )}
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  if (loading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-primary" />
+      </div>
+    )
+  }
+
+  if (!issue) {
+    return (
+      <div className="space-y-4 p-6 text-center">
+        <p className="text-muted-foreground">Goods issue not found</p>
+        <Button onClick={handleBack}>{t.back}</Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Button variant="ghost" size="sm" onClick={handleBack} className="-ml-2">
+              <ArrowLeft className="mr-1 h-4 w-4" />
+              {t.back}
+            </Button>
+            <Separator orientation="vertical" className="hidden h-5 md:block" />
+            <span>
+              {t.statusLabel}: <Badge className={statusColors[issue.status]}>{t[issue.status as keyof typeof t]}</Badge>
+            </span>
+          </div>
+          <h1 className="mt-2 text-2xl font-semibold tracking-tight">{t.title}</h1>
+          <p className="text-muted-foreground">{t.subtitle}</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline">
+            <UploadCloud className="mr-2 h-4 w-4" />
+            {t.exportPdf}
+          </Button>
+          <Button>
+            <CheckCircle className="mr-2 h-4 w-4" />
+            {t.approveAction}
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[2fr_1fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle>{t.information}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">{t.issueNo}</p>
+                <p className="text-base font-semibold">{issue.gi_no}</p>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">{t.issueType}</p>
+                <p>{t[issue.issue_type as keyof typeof t]}</p>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">{t.issueMethod}</p>
+                <p>{t[issue.issue_method as keyof typeof t]}</p>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">{t.expectedDate}</p>
+                <p>{new Date(issue.expected_date).toLocaleDateString(language === 'vn' ? 'vi-VN' : 'en-US')}</p>
+              </div>
+            </div>
+            <Separator />
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <User className="h-4 w-4" />
+                  <span>{t.createdBy}</span>
+                </div>
+                <p className="font-medium">{issue.created_by}</p>
+                <p className="text-sm text-muted-foreground">
+                  {t.createdAt}: {new Date(issue.created_at).toLocaleString(language === 'vn' ? 'vi-VN' : 'en-US')}
+                </p>
+              </div>
+              <div className="space-y-2">
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <ShieldCheck className="h-4 w-4" />
+                  <span>{t.approvedBy}</span>
+                </div>
+                <p className="font-medium">{issue.approved_by || '-'}</p>
+                <p className="text-sm text-muted-foreground">
+                  {t.approvedAt}: {issue.approved_at ? new Date(issue.approved_at).toLocaleString(language === 'vn' ? 'vi-VN' : 'en-US') : '-'}
+                </p>
+              </div>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <UploadCloud className="h-4 w-4" />
+                  <span>{t.submittedBy}</span>
+                </div>
+                <p className="font-medium">{issue.submitted_by || '-'}</p>
+                <p className="text-sm text-muted-foreground">
+                  {t.submittedAt}: {issue.submitted_at ? new Date(issue.submitted_at).toLocaleString(language === 'vn' ? 'vi-VN' : 'en-US') : '-'}
+                </p>
+              </div>
+              <div className="space-y-2">
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <FileText className="h-4 w-4" />
+                  <span>{t.remark}</span>
+                </div>
+                <p className="text-sm text-muted-foreground">{issue.remark || t.noRemark}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>{t.statusHistory}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {issue.histories.map(history => (
+              <div key={history.id} className="rounded-lg border p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <Badge className={statusColors[history.status]}>{t[history.status as keyof typeof t]}</Badge>
+                  <span className="text-sm text-muted-foreground">
+                    {new Date(history.timestamp).toLocaleString(language === 'vn' ? 'vi-VN' : 'en-US')}
+                  </span>
+                </div>
+                <p className="mt-2 text-sm font-medium">{history.action}</p>
+                <p className="text-sm text-muted-foreground">{history.actor}</p>
+                {history.remark && (
+                  <p className="mt-1 text-sm italic text-muted-foreground">{history.remark}</p>
+                )}
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[2fr_1fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle>{t.pickingResult}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>{t.modelCode}</TableHead>
+                    <TableHead>{t.modelName}</TableHead>
+                    <TableHead>{t.tracking}</TableHead>
+                    <TableHead>{t.uom}</TableHead>
+                    <TableHead>{t.qtyPlanned}</TableHead>
+                    <TableHead>{t.qtyPicked}</TableHead>
+                    <TableHead>{t.difference}</TableHead>
+                    <TableHead>{t.lineStatus}</TableHead>
+                    <TableHead className="text-right">{t.actions}</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {issue.lines.map(line => (
+                    <TableRow key={line.id}>
+                      <TableCell>{line.model_code}</TableCell>
+                      <TableCell>{line.model_name}</TableCell>
+                      <TableCell>{t[line.tracking_type as keyof typeof t]}</TableCell>
+                      <TableCell>{line.uom_code}</TableCell>
+                      <TableCell>{line.qty_planned}</TableCell>
+                      <TableCell>{line.qty_picked}</TableCell>
+                      <TableCell>
+                        <span className={line.difference < 0 ? 'text-destructive' : line.difference > 0 ? 'text-emerald-600' : ''}>
+                          {line.difference}
+                        </span>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={line.status === 'Completed' ? 'default' : line.status === 'Shortage' ? 'destructive' : 'secondary'}>
+                          {t[line.status as keyof typeof t]}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button variant="outline" size="sm" onClick={() => setSelectedLine(line)}>
+                          {t.view}
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+            <div className="grid gap-3 text-sm text-muted-foreground sm:grid-cols-3">
+              <div>
+                <span className="font-medium text-foreground">{t.totalPlanned}:</span> {summary.planned}
+              </div>
+              <div>
+                <span className="font-medium text-foreground">{t.totalPicked}:</span> {summary.picked}
+              </div>
+              <div>
+                <span className="font-medium text-foreground">{t.totalDifference}:</span>{' '}
+                <span className={summary.difference < 0 ? 'text-destructive' : summary.difference > 0 ? 'text-emerald-600' : ''}>
+                  {summary.difference}
+                </span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>{t.logistics}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <MapPin className="h-4 w-4" />
+                <span>{t.sourceWarehouse}</span>
+              </div>
+              <p className="font-medium">{issue.from_wh_name}</p>
+              <p className="text-sm text-muted-foreground">{issue.from_wh_code}</p>
+            </div>
+            {(issue.to_wh_name || issue.partner_name) && (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <MapPin className="h-4 w-4" />
+                  <span>{t.destination}</span>
+                </div>
+                <p className="font-medium">{issue.to_wh_name || issue.partner_name}</p>
+                <p className="text-sm text-muted-foreground">{issue.to_wh_code || issue.partner_code || '-'}</p>
+              </div>
+            )}
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <FileText className="h-4 w-4" />
+                <span>{t.attachments}</span>
+              </div>
+              {issue.attachments.length === 0 ? (
+                <p className="text-sm text-muted-foreground">{t.noAttachments}</p>
+              ) : (
+                <div className="space-y-3">
+                  {issue.attachments.map(file => (
+                    <div key={file.id} className="rounded-md border p-3">
+                      <p className="text-sm font-medium">{t.attachmentName}: {file.filename}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {t.attachmentUploadedBy}: {file.uploaded_by}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {t.attachmentUploadedAt}:{' '}
+                        {new Date(file.uploaded_at).toLocaleString(language === 'vn' ? 'vi-VN' : 'en-US')}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Dialog open={!!selectedLine} onOpenChange={open => !open && setSelectedLine(null)}>
+        <DialogContent className="max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>{t.trackingDialogTitle}</DialogTitle>
+            <DialogDescription>
+              {t.trackingDialogSubtitle}
+            </DialogDescription>
+          </DialogHeader>
+          {selectedLine && (
+            <div className="space-y-4">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div>
+                  <p className="text-sm text-muted-foreground">{t.modelCode}</p>
+                  <p className="font-medium">{selectedLine.model_code}</p>
+                </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">{t.modelName}</p>
+                  <p className="font-medium">{selectedLine.model_name}</p>
+                </div>
+                  <div>
+                    <p className="text-sm text-muted-foreground">{t.tracking}</p>
+                    <p className="font-medium">{t[selectedLine.tracking_type as keyof typeof t]}</p>
+                  </div>
+                <div>
+                  <p className="text-sm text-muted-foreground">{t.qtyPicked}</p>
+                  <p className="font-medium">{selectedLine.qty_picked}</p>
+                </div>
+              </div>
+              <Separator />
+              {renderTrackingContent(selectedLine)}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/src/components/goodsissue/GoodsIssueManagement.tsx
+++ b/src/components/goodsissue/GoodsIssueManagement.tsx
@@ -1,0 +1,429 @@
+import { useMemo, useState } from 'react'
+import {
+  Plus,
+  Search,
+  Filter,
+  FileDown,
+  Eye,
+  Send,
+  CheckCircle2,
+  X,
+  MoreHorizontal
+} from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Badge } from '../ui/badge'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '../ui/dropdown-menu'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '../ui/alert-dialog'
+import { useLanguage } from '../../contexts/LanguageContext'
+import { mockGoodsIssues } from '../../data/mockGoodsIssueData'
+import { GoodsIssue } from '../../types/goodsIssue'
+import { toast } from 'sonner@2.0.3'
+
+const translations = {
+  en: {
+    title: 'Goods Issue Management',
+    description: 'Track, review and approve all goods issue requests raised from the warehouse',
+    create: 'Create Goods Issue',
+    search: 'Search goods issue...',
+    filterStatus: 'Filter by Status',
+    filterType: 'Filter by Issue Type',
+    filterWarehouse: 'Filter by Source Warehouse',
+    filterPartner: 'Filter by Partner',
+    allStatuses: 'All Statuses',
+    allTypes: 'All Types',
+    allWarehouses: 'All Warehouses',
+    allPartners: 'All Partners',
+    export: 'Export',
+    view: 'View Detail',
+    submit: 'Submit',
+    approve: 'Approve',
+    cancel: 'Cancel',
+    confirmSubmit: 'Submit goods issue',
+    confirmSubmitDescription: 'Are you sure you want to submit this goods issue for approval?',
+    confirmApprove: 'Approve goods issue',
+    confirmApproveDescription: 'Confirm approval to post the picking result.',
+    confirmCancel: 'Cancel goods issue',
+    confirmCancelDescription: 'This will cancel the goods issue. The GI number will remain in history.',
+    issueNo: 'Goods Issue No',
+    issueType: 'Issue Type',
+    sourceWarehouse: 'Source Warehouse',
+    partner: 'Partner / Destination',
+    expectedDate: 'Expected Date',
+    status: 'Status',
+    actions: 'Actions',
+    total: 'Total',
+    records: 'records',
+    Draft: 'Draft',
+    Picking: 'Picking',
+    AdjustmentRequested: 'Adjustment Requested',
+    Submitted: 'Submitted',
+    Approved: 'Approved',
+    Completed: 'Completed',
+    Cancelled: 'Cancelled',
+    SO: 'Sales Order',
+    Transfer: 'Transfer',
+    ReturnToSupplier: 'Return to Supplier',
+    Adjustment: 'Adjustment',
+    Manual: 'Manual'
+  },
+  vn: {
+    title: 'Quản Lý Phiếu Xuất Kho',
+    description: 'Theo dõi, rà soát và phê duyệt tất cả yêu cầu xuất kho từ bộ phận kho',
+    create: 'Tạo phiếu xuất kho',
+    search: 'Tìm kiếm phiếu xuất...',
+    filterStatus: 'Lọc theo trạng thái',
+    filterType: 'Lọc theo loại phiếu',
+    filterWarehouse: 'Lọc theo kho xuất',
+    filterPartner: 'Lọc theo đối tác / kho nhận',
+    allStatuses: 'Tất cả trạng thái',
+    allTypes: 'Tất cả loại',
+    allWarehouses: 'Tất cả kho',
+    allPartners: 'Tất cả đối tác',
+    export: 'Xuất file',
+    view: 'Xem chi tiết',
+    submit: 'Gửi duyệt',
+    approve: 'Phê duyệt',
+    cancel: 'Hủy phiếu',
+    confirmSubmit: 'Gửi phiếu xuất',
+    confirmSubmitDescription: 'Bạn có chắc chắn muốn gửi phiếu này để phê duyệt?',
+    confirmApprove: 'Phê duyệt phiếu xuất',
+    confirmApproveDescription: 'Xác nhận phê duyệt để ghi nhận kết quả picking.',
+    confirmCancel: 'Hủy phiếu xuất',
+    confirmCancelDescription: 'Phiếu sẽ bị hủy nhưng vẫn giữ lại số phiếu trong lịch sử.',
+    issueNo: 'Số phiếu xuất kho',
+    issueType: 'Loại phiếu',
+    sourceWarehouse: 'Kho xuất',
+    partner: 'Đối tác / Kho nhận',
+    expectedDate: 'Ngày dự kiến',
+    status: 'Trạng thái',
+    actions: 'Thao tác',
+    total: 'Tổng',
+    records: 'phiếu',
+    Draft: 'Nháp',
+    Picking: 'Đang picking',
+    AdjustmentRequested: 'Yêu cầu điều chỉnh',
+    Submitted: 'Đã gửi',
+    Approved: 'Đã duyệt',
+    Completed: 'Hoàn tất',
+    Cancelled: 'Đã hủy',
+    SO: 'Đơn bán hàng',
+    Transfer: 'Chuyển kho',
+    ReturnToSupplier: 'Trả NCC',
+    Adjustment: 'Điều chỉnh',
+    Manual: 'Thủ công'
+  }
+}
+
+const statusColors = {
+  Draft: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200',
+  Picking: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+  AdjustmentRequested: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+  Submitted: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200',
+  Approved: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200',
+  Completed: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+  Cancelled: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
+} as const
+
+export function GoodsIssueManagement() {
+  const { language } = useLanguage()
+  const t = translations[language]
+
+  const [issues, setIssues] = useState<GoodsIssue[]>(mockGoodsIssues)
+  const [searchTerm, setSearchTerm] = useState('')
+  const [statusFilter, setStatusFilter] = useState('all')
+  const [typeFilter, setTypeFilter] = useState('all')
+  const [warehouseFilter, setWarehouseFilter] = useState('all')
+  const [partnerFilter, setPartnerFilter] = useState('all')
+  const [confirmAction, setConfirmAction] = useState<'submit' | 'approve' | 'cancel' | null>(null)
+  const [selectedIssue, setSelectedIssue] = useState<GoodsIssue | null>(null)
+
+  const warehouses = [...new Set(issues.map(issue => issue.from_wh_name).filter(Boolean))]
+  const partnersOrDestinations = [
+    ...new Set(
+      issues
+        .map(issue => issue.partner_name || issue.to_wh_name || '')
+        .filter(Boolean)
+    )
+  ]
+
+  const filteredIssues = useMemo(() => {
+    return issues.filter(issue => {
+      const matchesSearch =
+        issue.gi_no.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        issue.partner_name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        issue.to_wh_name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        issue.from_wh_name.toLowerCase().includes(searchTerm.toLowerCase())
+
+      const matchesStatus = statusFilter === 'all' || issue.status === statusFilter
+      const matchesType = typeFilter === 'all' || issue.issue_type === typeFilter
+      const matchesWarehouse = warehouseFilter === 'all' || issue.from_wh_name === warehouseFilter
+      const matchesPartner =
+        partnerFilter === 'all' || issue.partner_name === partnerFilter || issue.to_wh_name === partnerFilter
+
+      return matchesSearch && matchesStatus && matchesType && matchesWarehouse && matchesPartner
+    })
+  }, [issues, searchTerm, statusFilter, typeFilter, warehouseFilter, partnerFilter])
+
+  const handleNavigateDetail = (issue: GoodsIssue) => {
+    localStorage.setItem('viewingGoodsIssueId', issue.id)
+    window.location.hash = '#warehouse/goods-issue/view'
+  }
+
+  const updateIssueStatus = (issue: GoodsIssue, status: GoodsIssue['status']) => {
+    setIssues(prev => prev.map(item => (item.id === issue.id ? { ...item, status } : item)))
+    const statusLabel = t[status as keyof typeof t] || status
+    toast.success(`${statusLabel} - ${issue.gi_no}`)
+  }
+
+  const handleConfirmAction = () => {
+    if (!selectedIssue || !confirmAction) return
+
+    if (confirmAction === 'submit') {
+      updateIssueStatus(selectedIssue, 'Submitted')
+    } else if (confirmAction === 'approve') {
+      updateIssueStatus(selectedIssue, 'Approved')
+    } else if (confirmAction === 'cancel') {
+      updateIssueStatus(selectedIssue, 'Cancelled')
+    }
+
+    setConfirmAction(null)
+    setSelectedIssue(null)
+  }
+
+  const renderActionDialog = () => {
+    if (!confirmAction || !selectedIssue) return null
+
+    const dialogCopy = {
+      submit: {
+        title: t.confirmSubmit,
+        description: t.confirmSubmitDescription
+      },
+      approve: {
+        title: t.confirmApprove,
+        description: t.confirmApproveDescription
+      },
+      cancel: {
+        title: t.confirmCancel,
+        description: t.confirmCancelDescription
+      }
+    }[confirmAction]
+
+    return (
+      <AlertDialog open onOpenChange={open => !open && setConfirmAction(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{dialogCopy.title}</AlertDialogTitle>
+            <AlertDialogDescription>{dialogCopy.description}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setConfirmAction(null)}>{t.cancel}</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmAction}>
+              {confirmAction === 'submit' ? t.submit : confirmAction === 'approve' ? t.approve : t.cancel}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    )
+  }
+
+  const renderActions = (issue: GoodsIssue) => (
+    <div className="flex items-center gap-2">
+      <Button variant="outline" size="sm" onClick={() => handleNavigateDetail(issue)}>
+        <Eye className="mr-1 h-4 w-4" />
+        {t.view}
+      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm">
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            onClick={() => {
+              setSelectedIssue(issue)
+              setConfirmAction('submit')
+            }}
+          >
+            <Send className="mr-2 h-4 w-4" />
+            {t.submit}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => {
+              setSelectedIssue(issue)
+              setConfirmAction('approve')
+            }}
+          >
+            <CheckCircle2 className="mr-2 h-4 w-4" />
+            {t.approve}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="text-destructive focus:text-destructive"
+            onClick={() => {
+              setSelectedIssue(issue)
+              setConfirmAction('cancel')
+            }}
+          >
+            <X className="mr-2 h-4 w-4" />
+            {t.cancel}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">{t.title}</h1>
+          <p className="text-muted-foreground">{t.description}</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button>
+            <Plus className="mr-2 h-4 w-4" />
+            {t.create}
+          </Button>
+          <Button variant="outline">
+            <FileDown className="mr-2 h-4 w-4" />
+            {t.export}
+          </Button>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <CardTitle className="text-base font-medium">{t.filterStatus}</CardTitle>
+          <div className="flex w-full flex-col gap-3 md:w-auto md:flex-row">
+            <div className="relative md:w-72">
+              <Search className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                className="pl-9"
+                placeholder={t.search}
+                value={searchTerm}
+                onChange={event => setSearchTerm(event.target.value)}
+              />
+            </div>
+            <div className="flex flex-col gap-3 md:flex-row">
+              <Select value={statusFilter} onValueChange={setStatusFilter}>
+                <SelectTrigger className="md:w-48">
+                  <Filter className="mr-2 h-4 w-4" />
+                  <SelectValue placeholder={t.filterStatus} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t.allStatuses}</SelectItem>
+                  {['Draft', 'Picking', 'AdjustmentRequested', 'Submitted', 'Approved', 'Completed', 'Cancelled'].map(status => (
+                    <SelectItem key={status} value={status}>
+                      {t[status as keyof typeof t]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Select value={typeFilter} onValueChange={setTypeFilter}>
+                <SelectTrigger className="md:w-48">
+                  <Filter className="mr-2 h-4 w-4" />
+                  <SelectValue placeholder={t.filterType} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t.allTypes}</SelectItem>
+                  {['SO', 'Transfer', 'ReturnToSupplier', 'Adjustment', 'Manual'].map(type => (
+                    <SelectItem key={type} value={type}>
+                      {t[type as keyof typeof t]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Select value={warehouseFilter} onValueChange={setWarehouseFilter}>
+                <SelectTrigger className="md:w-48">
+                  <Filter className="mr-2 h-4 w-4" />
+                  <SelectValue placeholder={t.filterWarehouse} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t.allWarehouses}</SelectItem>
+                  {warehouses.map(warehouse => (
+                    <SelectItem key={warehouse} value={warehouse}>
+                      {warehouse}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Select value={partnerFilter} onValueChange={setPartnerFilter}>
+                <SelectTrigger className="md:w-48">
+                  <Filter className="mr-2 h-4 w-4" />
+                  <SelectValue placeholder={t.filterPartner} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t.allPartners}</SelectItem>
+                  {partnersOrDestinations.map(partner => (
+                    <SelectItem key={partner} value={partner}>
+                      {partner}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="min-w-[160px]">{t.issueNo}</TableHead>
+                  <TableHead>{t.issueType}</TableHead>
+                  <TableHead>{t.sourceWarehouse}</TableHead>
+                  <TableHead>{t.partner}</TableHead>
+                  <TableHead>{t.expectedDate}</TableHead>
+                  <TableHead>{t.status}</TableHead>
+                  <TableHead className="text-right">{t.actions}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredIssues.map(issue => (
+                  <TableRow key={issue.id} className="hover:bg-muted/50">
+                    <TableCell className="font-medium">
+                      <div className="flex flex-col">
+                        <span>{issue.gi_no}</span>
+                        <span className="text-xs text-muted-foreground">
+                          {t.total}: {issue.lines.length} / {issue.lines.reduce((acc, line) => acc + line.qty_planned, 0)}
+                        </span>
+                      </div>
+                    </TableCell>
+                    <TableCell>{t[issue.issue_type as keyof typeof t]}</TableCell>
+                    <TableCell>{issue.from_wh_name}</TableCell>
+                    <TableCell>{issue.partner_name || issue.to_wh_name || '-'}</TableCell>
+                    <TableCell>{new Date(issue.expected_date).toLocaleDateString(language === 'vn' ? 'vi-VN' : 'en-US')}</TableCell>
+                    <TableCell>
+                      <Badge className={statusColors[issue.status]}>{t[issue.status as keyof typeof t]}</Badge>
+                    </TableCell>
+                    <TableCell className="text-right">{renderActions(issue)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+          <div className="flex justify-between text-sm text-muted-foreground">
+            <div>
+              {t.total}: {filteredIssues.length} {t.records}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {renderActionDialog()}
+    </div>
+  )
+}

--- a/src/data/mockGoodsIssueData.ts
+++ b/src/data/mockGoodsIssueData.ts
@@ -1,0 +1,353 @@
+import { GoodsIssue, GoodsIssueHistory, GoodsIssueLine, GoodsIssuePickingRecord } from '../types/goodsIssue'
+import { mockModelAssets } from './mockModelAssetData'
+import { mockWarehouses } from './mockWarehouseData'
+import { mockPartners } from './mockPartnerData'
+import { mockUoMs } from './mockUomData'
+
+const findModel = (modelCode: string) => mockModelAssets.find(model => model.model_code === modelCode)
+const findWarehouse = (code: string) => mockWarehouses.find(wh => wh.code === code)
+const findPartner = (code: string) => mockPartners.find(partner => partner.partner_code === code)
+const findUom = (code: string) => mockUoMs.find(uom => uom.uom_code === code)
+
+const createSerialPickings = (lineId: string, serials: string[]): GoodsIssuePickingRecord[] =>
+  serials.map((serial, index) => ({
+    id: `${lineId}-serial-${index + 1}`,
+    line_id: lineId,
+    tracking_type: 'Serial',
+    serial_no: serial,
+    qty_picked: 1,
+    location_code: index % 2 === 0 ? 'BIN-A01' : 'BIN-A02',
+    picked_by: index % 2 === 0 ? 'Nguyen Van A' : 'Tran Thi B',
+    picked_at: `2024-03-1${index}T10:${20 + index}:00Z`
+  }))
+
+const createLotPickings = (
+  lineId: string,
+  lots: { lot_no: string; qty: number; received_date: string }[]
+): GoodsIssuePickingRecord[] =>
+  lots.map((lot, index) => ({
+    id: `${lineId}-lot-${index + 1}`,
+    line_id: lineId,
+    tracking_type: 'Lot',
+    lot_no: lot.lot_no,
+    qty_picked: lot.qty,
+    received_date: lot.received_date,
+    location_code: index % 2 === 0 ? 'RACK-B01' : 'RACK-B02',
+    picked_by: index % 2 === 0 ? 'Le Van C' : 'Pham Thi D',
+    picked_at: `2024-03-15T0${index + 8}:30:00Z`
+  }))
+
+const laptopModel = findModel('MD_006')
+const printerModel = findModel('MD_002')
+const cableModel = findModel('MD_004')
+const chairModel = findModel('MD_003')
+
+const mainWarehouse = findWarehouse('WH01')
+const branchWarehouse = findWarehouse('WH02')
+const storageWarehouse = findWarehouse('WH03')
+
+const partnerVNTech = findPartner('CUS001')
+const partnerSupplier = findPartner('SUP001')
+
+const pcsUom = findUom('PCS')
+const kgUom = findUom('KG')
+
+const linesForTransfer: GoodsIssueLine[] = [
+  {
+    id: 'gi-line-1',
+    model_id: laptopModel?.id || '6',
+    model_code: laptopModel?.model_code || 'MD_006',
+    model_name: laptopModel?.model_name || 'Microsoft Surface Laptop 5',
+    uom_id: pcsUom?.id || '1',
+    uom_code: pcsUom?.uom_code || 'PCS',
+    uom_name: pcsUom?.uom_name || 'Pieces',
+    tracking_type: 'Serial',
+    qty_planned: 10,
+    qty_picked: 9,
+    issue_method: 'Serial',
+    difference: -1,
+    status: 'Picking',
+    pickings: createSerialPickings('gi-line-1', [
+      'SN-20240315001',
+      'SN-20240315002',
+      'SN-20240315003',
+      'SN-20240315004',
+      'SN-20240315005',
+      'SN-20240315006',
+      'SN-20240315007',
+      'SN-20240315008',
+      'SN-20240315009'
+    ])
+  },
+  {
+    id: 'gi-line-2',
+    model_id: cableModel?.id || '4',
+    model_code: cableModel?.model_code || 'MD_004',
+    model_name: cableModel?.model_name || 'Network Cable Cat6',
+    uom_id: kgUom?.id || '6',
+    uom_code: kgUom?.uom_code || 'KG',
+    uom_name: kgUom?.uom_name || 'Kilogram',
+    tracking_type: 'Lot',
+    qty_planned: 50,
+    qty_picked: 50,
+    issue_method: 'Lot',
+    difference: 0,
+    status: 'Completed',
+    pickings: createLotPickings('gi-line-2', [
+      { lot_no: 'LOT-2308A', qty: 30, received_date: '2023-08-20T00:00:00Z' },
+      { lot_no: 'LOT-2312B', qty: 20, received_date: '2023-12-05T00:00:00Z' }
+    ])
+  }
+]
+
+const linesForSales: GoodsIssueLine[] = [
+  {
+    id: 'gi-line-3',
+    model_id: printerModel?.id || '2',
+    model_code: printerModel?.model_code || 'MD_002',
+    model_name: printerModel?.model_name || 'HP LaserJet Pro 404dn',
+    uom_id: pcsUom?.id || '1',
+    uom_code: pcsUom?.uom_code || 'PCS',
+    uom_name: pcsUom?.uom_name || 'Pieces',
+    tracking_type: 'Serial',
+    qty_planned: 5,
+    qty_picked: 5,
+    issue_method: 'Serial',
+    difference: 0,
+    status: 'Completed',
+    pickings: createSerialPickings('gi-line-3', [
+      'SN-PR404-1001',
+      'SN-PR404-1002',
+      'SN-PR404-1003',
+      'SN-PR404-1004',
+      'SN-PR404-1005'
+    ])
+  },
+  {
+    id: 'gi-line-4',
+    model_id: chairModel?.id || '3',
+    model_code: chairModel?.model_code || 'MD_003',
+    model_name: chairModel?.model_name || 'Office Chair Ergonomic',
+    uom_id: pcsUom?.id || '1',
+    uom_code: pcsUom?.uom_code || 'PCS',
+    uom_name: pcsUom?.uom_name || 'Pieces',
+    tracking_type: 'None',
+    qty_planned: 20,
+    qty_picked: 18,
+    issue_method: 'Model',
+    difference: -2,
+    status: 'Shortage',
+    pickings: [
+      {
+        id: 'gi-line-4-none-1',
+        line_id: 'gi-line-4',
+        tracking_type: 'None',
+        qty_picked: 18,
+        location_code: 'AISLE-C03',
+        picked_by: 'Nguyen Van A',
+        picked_at: '2024-03-12T09:45:00Z',
+        note: '2 chairs with damaged armrests reported'
+      }
+    ]
+  }
+]
+
+const transferHistories: GoodsIssueHistory[] = [
+  {
+    id: 'history-1',
+    status: 'Draft',
+    action: 'Draft created',
+    actor: 'Le Thi Planning',
+    timestamp: '2024-03-10T08:15:00Z'
+  },
+  {
+    id: 'history-2',
+    status: 'Picking',
+    action: 'Picking started',
+    actor: 'Nguyen Van A',
+    timestamp: '2024-03-12T09:00:00Z',
+    remark: 'Assigned to picking team'
+  },
+  {
+    id: 'history-3',
+    status: 'AdjustmentRequested',
+    action: 'Adjustment requested',
+    actor: 'Nguyen Van A',
+    timestamp: '2024-03-12T10:20:00Z',
+    remark: 'Missing 1 Surface Laptop due to QC hold'
+  },
+  {
+    id: 'history-4',
+    status: 'Submitted',
+    action: 'Submitted for approval',
+    actor: 'Tran Thi B',
+    timestamp: '2024-03-12T11:00:00Z'
+  }
+]
+
+const salesHistories: GoodsIssueHistory[] = [
+  {
+    id: 'history-5',
+    status: 'Draft',
+    action: 'Draft created',
+    actor: 'Le Thi Planning',
+    timestamp: '2024-03-05T07:30:00Z'
+  },
+  {
+    id: 'history-6',
+    status: 'Picking',
+    action: 'Picking started',
+    actor: 'Pham Thi D',
+    timestamp: '2024-03-06T08:45:00Z'
+  },
+  {
+    id: 'history-7',
+    status: 'Submitted',
+    action: 'Submitted for approval',
+    actor: 'Pham Thi D',
+    timestamp: '2024-03-06T10:15:00Z'
+  },
+  {
+    id: 'history-8',
+    status: 'Approved',
+    action: 'Approved by warehouse manager',
+    actor: 'Vo Quang Manager',
+    timestamp: '2024-03-06T11:30:00Z'
+  },
+  {
+    id: 'history-9',
+    status: 'Completed',
+    action: 'Inventory posted',
+    actor: 'System',
+    timestamp: '2024-03-06T12:00:00Z'
+  }
+]
+
+export const mockGoodsIssues: GoodsIssue[] = [
+  {
+    id: 'GI-20240312-001',
+    gi_no: 'GI-WH01-20240312-001',
+    issue_type: 'Transfer',
+    issue_method: 'Serial',
+    from_wh_id: mainWarehouse?.id || '1',
+    from_wh_code: mainWarehouse?.code || 'WH01',
+    from_wh_name: mainWarehouse?.name || 'Main Warehouse',
+    to_wh_id: branchWarehouse?.id,
+    to_wh_code: branchWarehouse?.code,
+    to_wh_name: branchWarehouse?.name,
+    expected_date: '2024-03-13T00:00:00Z',
+    remark: 'Transfer laptops to branch for onboarding batch 03/2024',
+    status: 'Submitted',
+    created_by: 'Le Thi Planning',
+    created_at: '2024-03-10T08:15:00Z',
+    submitted_by: 'Tran Thi B',
+    submitted_at: '2024-03-12T11:00:00Z',
+    lines: linesForTransfer,
+    attachments: [
+      {
+        id: 'att-1',
+        filename: 'packing-list.pdf',
+        file_size: 245_000,
+        file_type: 'application/pdf',
+        uploaded_at: '2024-03-12T07:55:00Z',
+        uploaded_by: 'Nguyen Van A'
+      },
+      {
+        id: 'att-2',
+        filename: 'handover-form.xlsx',
+        file_size: 125_000,
+        file_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        uploaded_at: '2024-03-12T08:05:00Z',
+        uploaded_by: 'Tran Thi B'
+      }
+    ],
+    histories: transferHistories
+  },
+  {
+    id: 'GI-20240306-002',
+    gi_no: 'GI-WH01-20240306-002',
+    issue_type: 'SO',
+    issue_method: 'Serial',
+    from_wh_id: mainWarehouse?.id || '1',
+    from_wh_code: mainWarehouse?.code || 'WH01',
+    from_wh_name: mainWarehouse?.name || 'Main Warehouse',
+    partner_id: partnerVNTech?.id,
+    partner_code: partnerVNTech?.partner_code,
+    partner_name: partnerVNTech?.partner_name,
+    expected_date: '2024-03-06T00:00:00Z',
+    remark: 'Sales order SO-20240305-015 for VNTech',
+    status: 'Completed',
+    created_by: 'Le Thi Planning',
+    created_at: '2024-03-05T07:30:00Z',
+    submitted_by: 'Pham Thi D',
+    submitted_at: '2024-03-06T10:15:00Z',
+    approved_by: 'Vo Quang Manager',
+    approved_at: '2024-03-06T11:30:00Z',
+    completed_at: '2024-03-06T12:00:00Z',
+    lines: linesForSales,
+    attachments: [
+      {
+        id: 'att-3',
+        filename: 'delivery-note.pdf',
+        file_size: 310_000,
+        file_type: 'application/pdf',
+        uploaded_at: '2024-03-06T09:50:00Z',
+        uploaded_by: 'Pham Thi D'
+      }
+    ],
+    histories: salesHistories
+  },
+  {
+    id: 'GI-20240308-003',
+    gi_no: 'GI-WH03-20240308-003',
+    issue_type: 'ReturnToSupplier',
+    issue_method: 'Lot',
+    from_wh_id: storageWarehouse?.id || '3',
+    from_wh_code: storageWarehouse?.code || 'WH03',
+    from_wh_name: storageWarehouse?.name || 'Storage Warehouse',
+    partner_id: partnerSupplier?.id,
+    partner_code: partnerSupplier?.partner_code,
+    partner_name: partnerSupplier?.partner_name,
+    expected_date: '2024-03-09T00:00:00Z',
+    remark: 'Return defective batch LOT-2312B to supplier',
+    status: 'Picking',
+    created_by: 'Hoang Thi Logistics',
+    created_at: '2024-03-07T13:20:00Z',
+    lines: [linesForTransfer[1]],
+    attachments: [],
+    histories: [
+      {
+        id: 'history-10',
+        status: 'Draft',
+        action: 'Draft created',
+        actor: 'Hoang Thi Logistics',
+        timestamp: '2024-03-07T13:20:00Z'
+      },
+      {
+        id: 'history-11',
+        status: 'Picking',
+        action: 'Picking in progress',
+        actor: 'Le Van C',
+        timestamp: '2024-03-08T08:45:00Z'
+      }
+    ]
+  }
+]
+
+export const getGoodsIssueById = (id: string): GoodsIssue | undefined =>
+  mockGoodsIssues.find(issue => issue.id === id)
+
+export const getGoodsIssueSummaries = () =>
+  mockGoodsIssues.map(issue => ({
+    id: issue.id,
+    gi_no: issue.gi_no,
+    issue_type: issue.issue_type,
+    status: issue.status,
+    expected_date: issue.expected_date,
+    from_wh_name: issue.from_wh_name,
+    to_wh_name: issue.to_wh_name,
+    partner_name: issue.partner_name,
+    total_lines: issue.lines.length,
+    total_qty_planned: issue.lines.reduce((acc, line) => acc + line.qty_planned, 0),
+    total_qty_picked: issue.lines.reduce((acc, line) => acc + line.qty_picked, 0)
+  }))

--- a/src/types/goodsIssue.ts
+++ b/src/types/goodsIssue.ts
@@ -1,0 +1,90 @@
+export type GoodsIssueType = 'SO' | 'Transfer' | 'ReturnToSupplier' | 'Adjustment' | 'Manual'
+
+export type GoodsIssueStatus =
+  | 'Draft'
+  | 'Picking'
+  | 'AdjustmentRequested'
+  | 'Submitted'
+  | 'Approved'
+  | 'Completed'
+  | 'Cancelled'
+
+export interface GoodsIssueAttachment {
+  id: string
+  filename: string
+  file_size: number
+  file_type: string
+  uploaded_at: string
+  uploaded_by: string
+}
+
+export interface GoodsIssueHistory {
+  id: string
+  status: GoodsIssueStatus
+  action: string
+  actor: string
+  timestamp: string
+  remark?: string
+}
+
+export interface GoodsIssuePickingRecord {
+  id: string
+  line_id: string
+  tracking_type: 'Serial' | 'Lot' | 'None'
+  serial_no?: string
+  lot_no?: string
+  qty_picked?: number
+  received_date?: string
+  location_code?: string
+  picked_by: string
+  picked_at: string
+  note?: string
+}
+
+export interface GoodsIssueLine {
+  id: string
+  model_id: string
+  model_code: string
+  model_name: string
+  uom_id: string
+  uom_code: string
+  uom_name: string
+  tracking_type: 'Serial' | 'Lot' | 'None'
+  qty_planned: number
+  qty_picked: number
+  issue_method: 'Model' | 'Serial' | 'Lot'
+  difference: number
+  status: 'Pending' | 'Picking' | 'Completed' | 'Shortage'
+  remarks?: string
+  pickings: GoodsIssuePickingRecord[]
+}
+
+export interface GoodsIssue {
+  id: string
+  gi_no: string
+  issue_type: GoodsIssueType
+  issue_method: 'Model' | 'Serial' | 'Lot'
+  from_wh_id: string
+  from_wh_code: string
+  from_wh_name: string
+  to_wh_id?: string
+  to_wh_code?: string
+  to_wh_name?: string
+  partner_id?: string
+  partner_code?: string
+  partner_name?: string
+  expected_date: string
+  remark?: string
+  status: GoodsIssueStatus
+  created_by: string
+  created_at: string
+  submitted_by?: string
+  submitted_at?: string
+  approved_by?: string
+  approved_at?: string
+  completed_at?: string
+  cancelled_at?: string
+  lines: GoodsIssueLine[]
+  attachments: GoodsIssueAttachment[]
+  histories: GoodsIssueHistory[]
+}


### PR DESCRIPTION
## Summary
- define goods issue types and mock data linked to existing master catalog records
- add a goods issue management list with filtering, workflow actions, and router integration
- build a detailed goods issue view showing tracking allocations, status history, and logistics context

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca67ab96c08325b77a5907a4011f1f