### PR TITLE
fix: update sonner imports

### DIFF
--- a/src/components/Toaster.tsx
+++ b/src/components/Toaster.tsx
@@ -1,4 +1,4 @@
-import { Toaster as Sonner } from "sonner@2.0.3"
+import { Toaster as Sonner } from "sonner"
 import { useTheme } from "../contexts/ThemeContext"
 
 export function Toaster() {

--- a/src/components/assettype/AssetTypeManagement.tsx
+++ b/src/components/assettype/AssetTypeManagement.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../ui/table";
 import { Badge } from "../ui/badge";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../ui/dialog";
-import { toast } from "sonner@2.0.3";
+import { toast } from "sonner";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { AssetType, AssetTypeFilters, AssetTypeFormData } from "../../types/assetType";
 import { getAssetTypes, createAssetType, updateAssetType } from "../../data/mockAssetTypeData";

--- a/src/components/branch/BranchManagement.tsx
+++ b/src/components/branch/BranchManagement.tsx
@@ -12,7 +12,7 @@ import { Organization } from '../../types/organization'
 import { BranchForm } from './BranchForm'
 import { useLanguage } from '../../contexts/LanguageContext'
 import { getBranches, createBranch, updateBranch, deleteBranch, getActiveOrganizations } from '../../data/mockBranchData'
-import { toast } from 'sonner@2.0.3'
+import { toast } from 'sonner'
 import { Plus, Search, MoreHorizontal, Edit, Trash2, GitBranch, Building2, CheckCircle, XCircle } from 'lucide-react'
 
 const translations = {

--- a/src/components/goodsreceipt/GoodsReceiptApproval.tsx
+++ b/src/components/goodsreceipt/GoodsReceiptApproval.tsx
@@ -15,7 +15,7 @@ import { useLanguage } from '../../contexts/LanguageContext'
 import { GoodsReceipt, GoodsReceiptWarning, GoodsReceiptActualRecord, GoodsReceiptAuditLog } from '../../types/goodsReceipt'
 import { mockGoodsReceipts, mockWarnings, mockAuditLogs } from '../../data/mockGoodsReceiptData'
 import { GoodsReceiptSpecialActions } from './GoodsReceiptSpecialActions'
-import { toast } from 'sonner@2.0.3'
+import { toast } from 'sonner'
 
 const translations = {
   en: {

--- a/src/components/goodsreceipt/GoodsReceiptFormPage.tsx
+++ b/src/components/goodsreceipt/GoodsReceiptFormPage.tsx
@@ -21,7 +21,7 @@ import { mockUoMs } from '../../data/mockUomData'
 import { generateReceiptNumber, mockGoodsReceipts } from '../../data/mockGoodsReceiptData'
 import { WarehouseSelectWithSearch } from './WarehouseSelectWithSearch'
 import { PartnerSelectWithSearch } from './PartnerSelectWithSearch'
-import { toast } from 'sonner@2.0.3'
+import { toast } from 'sonner'
 
 const translations = {
   en: {

--- a/src/components/goodsreceipt/GoodsReceiptFormWrapper.tsx
+++ b/src/components/goodsreceipt/GoodsReceiptFormWrapper.tsx
@@ -6,7 +6,7 @@ import { useLanguage } from '../../contexts/LanguageContext'
 import { GoodsReceiptForm } from './GoodsReceiptFormFixed'
 import { mockGoodsReceipts } from '../../data/mockGoodsReceiptData'
 import { GoodsReceipt } from '../../types/goodsReceipt'
-import { toast } from 'sonner@2.0.3'
+import { toast } from 'sonner'
 
 const translations = {
   en: {

--- a/src/components/goodsreceipt/GoodsReceiptManagement.tsx
+++ b/src/components/goodsreceipt/GoodsReceiptManagement.tsx
@@ -13,7 +13,7 @@ import { useLanguage } from '../../contexts/LanguageContext'
 
 import { mockGoodsReceipts } from '../../data/mockGoodsReceiptData'
 import { GoodsReceipt } from '../../types/goodsReceipt'
-import { toast } from 'sonner@2.0.3'
+import { toast } from 'sonner'
 
 const translations = {
   en: {

--- a/src/components/goodsreceipt/GoodsReceiptSpecialActions.tsx
+++ b/src/components/goodsreceipt/GoodsReceiptSpecialActions.tsx
@@ -8,7 +8,7 @@ import { Alert, AlertDescription } from '../ui/alert'
 import { Badge } from '../ui/badge'
 import { useLanguage } from '../../contexts/LanguageContext'
 import { GoodsReceipt } from '../../types/goodsReceipt'
-import { toast } from 'sonner@2.0.3'
+import { toast } from 'sonner'
 
 const translations = {
   en: {

--- a/src/components/goodsreceipt/GoodsReceiptSubmit.tsx
+++ b/src/components/goodsreceipt/GoodsReceiptSubmit.tsx
@@ -11,7 +11,7 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import { useLanguage } from '../../contexts/LanguageContext'
 import { mockGoodsReceipts } from '../../data/mockGoodsReceiptData'
 import { GoodsReceipt, GoodsReceiptLine } from '../../types/goodsReceipt'
-import { toast } from 'sonner@2.0.3'
+import { toast } from 'sonner'
 
 const translations = {
   en: {

--- a/src/components/location/LocationManagement.tsx
+++ b/src/components/location/LocationManagement.tsx
@@ -11,7 +11,7 @@ import { LocationForm } from "./LocationForm";
 import { Location, CreateLocationData, UpdateLocationData } from "../../types/location";
 import { getLocations, createLocation, updateLocation, getActiveAssetTypes, getWarehousesForLocation } from "../../data/mockLocationData";
 import { useLanguage } from "../../contexts/LanguageContext";
-import { toast } from "sonner@2.0.3";
+import { toast } from "sonner";
 
 export function LocationManagement() {
   const { language } = useLanguage();

--- a/src/components/organization/OrganizationManagement.tsx
+++ b/src/components/organization/OrganizationManagement.tsx
@@ -11,7 +11,7 @@ import { Organization, OrganizationFormData } from '../../types/organization'
 import { OrganizationForm } from './OrganizationForm'
 import { useLanguage } from '../../contexts/LanguageContext'
 import { getOrganizations, createOrganization, updateOrganization, deleteOrganization } from '../../data/mockOrganizationData'
-import { toast } from 'sonner@2.0.3'
+import { toast } from 'sonner'
 import { Plus, Search, MoreHorizontal, Edit, Trash2, Building2, Users, CheckCircle, XCircle } from 'lucide-react'
 
 const translations = {

--- a/src/components/partner/PartnerForm.tsx
+++ b/src/components/partner/PartnerForm.tsx
@@ -7,7 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { Textarea } from '../ui/textarea';
 import { Partner, CreatePartnerData, UpdatePartnerData } from '../../types/partner';
 import { mockPartners, getPartnersWithOpenDocuments } from '../../data/mockPartnerData';
-import { toast } from 'sonner@2.0.3';
+import { toast } from 'sonner';
 import { useLanguage } from '../../contexts/LanguageContext';
 
 interface PartnerFormProps {

--- a/src/components/stockonhand/AssetNoneManagement.tsx
+++ b/src/components/stockonhand/AssetNoneManagement.tsx
@@ -15,7 +15,7 @@ import { mockWarehouses } from '../../data/mockWarehouseData'
 import { mockLocations } from '../../data/mockLocationData'
 import { AssetNoneForm } from './AssetNoneForm'
 import { Plus, Search, Pencil, Trash2, List, AlertTriangle, X } from 'lucide-react'
-import { toast } from 'sonner@2.0.3'
+import { toast } from 'sonner'
 
 export function AssetNoneManagement() {
   const { language } = useLanguage()

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTheme } from "next-themes@0.4.6";
-import { Toaster as Sonner, ToasterProps } from "sonner@2.0.3";
+import { Toaster as Sonner, ToasterProps } from "sonner";
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme();

--- a/src/components/uom/UoMManagement.tsx
+++ b/src/components/uom/UoMManagement.tsx
@@ -23,7 +23,7 @@ import {
   Info,
   Trash2
 } from "lucide-react"
-import { toast } from "sonner@2.0.3"
+import { toast } from "sonner"
 
 export function UoMManagement() {
   const [uoms, setUoMs] = useState<UoM[]>(mockUoMs)

--- a/src/components/warehouse/WarehouseManagement.tsx
+++ b/src/components/warehouse/WarehouseManagement.tsx
@@ -31,7 +31,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
 import { WarehouseForm } from './WarehouseForm'
 import { Plus, Search, MoreHorizontal, Edit, Trash2, Eye, EyeOff, Filter, X } from 'lucide-react'
-import { toast } from 'sonner@2.0.3'
+import { toast } from 'sonner'
 import { useLanguage } from '../../contexts/LanguageContext'
 import { mockWarehouses } from '../../data/mockWarehouseData'
 import { getWarehouseOrganizations } from '../../data/mockOrganizationData'


### PR DESCRIPTION
## Summary
- update all sonner toast imports to use the base `sonner` package path
- align the shared toaster component with the new import path
- ensure ui sonner wrapper references the corrected module

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca723bcf7883259142759c038f0649
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update all `sonner` imports to use base package path for consistency and future-proofing.
> 
>   - **Imports**:
>     - Update all `sonner` imports to use base package path instead of version-specific path in `Toaster.tsx`, `AssetTypeManagement.tsx`, and `BranchManagement.tsx`.
>     - Align `Toaster` component in `Toaster.tsx` with new import path.
>     - Ensure `ui/sonner.tsx` references corrected module.
>   - **Testing**:
>     - Run `npm run build` to ensure no build errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tringuyen111%2Fproject_tri_inventory&utm_source=github&utm_medium=referral)<sup> for 3b50bca57f1abb9b96bcad5228da3c4739138054. You can [customize](https://app.ellipsis.dev/tringuyen111/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->