### PR TITLE
Add goods issue draft workflow and routing

### DIFF
--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -14,6 +14,8 @@ import { GoodsReceiptFormWrapper } from './goodsreceipt/GoodsReceiptFormWrapper'
 import { GoodsReceiptDetail } from './goodsreceipt/GoodsReceiptDetail'
 import { GoodsReceiptApproval } from './goodsreceipt/GoodsReceiptApproval'
 import { GoodsReceiptSubmit } from './goodsreceipt/GoodsReceiptSubmit'
+import { GoodsIssueManagement } from './goodsissue/GoodsIssueManagement'
+import { GoodsIssueFormWrapper } from './goodsissue/GoodsIssueFormWrapper'
 
 type RouteKey = 
   | 'dashboard' 
@@ -32,6 +34,8 @@ type RouteKey =
   | 'goodsreceipt/view'
   | 'goodsreceipt/approve'
   | 'goodsreceipt/submit'
+  | 'goodsissue'
+  | 'goodsissue/create'
 
 interface RouterProps {
   currentRoute: RouteKey
@@ -75,10 +79,14 @@ export function Router({ currentRoute }: RouterProps) {
       />
     case 'goodsreceipt/submit':
       const submitReceiptId = localStorage.getItem('submittingReceiptId')
-      return <GoodsReceiptSubmit 
-        receiptId={submitReceiptId || ''} 
-        onBack={() => window.location.hash = '#warehouse/goods-receipt'} 
+      return <GoodsReceiptSubmit
+        receiptId={submitReceiptId || ''}
+        onBack={() => window.location.hash = '#warehouse/goods-receipt'}
       />
+    case 'goodsissue':
+      return <GoodsIssueManagement />
+    case 'goodsissue/create':
+      return <GoodsIssueFormWrapper />
     case 'dashboard':
     default:
       return <MainContent />
@@ -109,6 +117,8 @@ export const useRouter = () => {
         'warehouse/goods-receipt/view': 'goodsreceipt/view',
         'warehouse/goods-receipt/approve': 'goodsreceipt/approve',
         'warehouse/goods-receipt/submit': 'goodsreceipt/submit',
+        'warehouse/goods-issue': 'goodsissue',
+        'warehouse/goods-issue/create': 'goodsissue/create',
         'dashboards': 'dashboard'
       }
       
@@ -141,7 +151,9 @@ export const useRouter = () => {
       'goodsreceipt/edit': '#warehouse/goods-receipt/edit',
       'goodsreceipt/view': '#warehouse/goods-receipt/view',
       'goodsreceipt/approve': '#warehouse/goods-receipt/approve',
-      'goodsreceipt/submit': '#warehouse/goods-receipt/submit'
+      'goodsreceipt/submit': '#warehouse/goods-receipt/submit',
+      'goodsissue': '#warehouse/goods-issue',
+      'goodsissue/create': '#warehouse/goods-issue/create'
     }
     
     window.location.hash = routeMap[route]

--- a/src/components/goodsissue/GoodsIssueFormWrapper.tsx
+++ b/src/components/goodsissue/GoodsIssueFormWrapper.tsx
@@ -1,0 +1,686 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useForm, useFieldArray, Controller } from 'react-hook-form@7.55.0'
+import { ArrowLeft, Plus, Trash2, Upload, Download, Info, Save } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Textarea } from '../ui/textarea'
+import { Label } from '../ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { Badge } from '../ui/badge'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog'
+import { useLanguage } from '../../contexts/LanguageContext'
+import {
+  enrichGoodsIssueLine,
+  generateGoodsIssueNumber,
+  logGoodsIssueAudit,
+  saveGoodsIssueDraft
+} from '../../data/mockGoodsIssueData'
+import { mockPartners } from '../../data/mockPartnerData'
+import { mockWarehouses } from '../../data/mockWarehouseData'
+import { mockModelAssets } from '../../data/mockModelAssetData'
+import { mockUoMs } from '../../data/mockUomData'
+import { GoodsIssue, GoodsIssueFormData, GoodsIssueTrackingType } from '../../types/goodsIssue'
+import { WarehouseSelectWithSearch } from '../goodsreceipt/WarehouseSelectWithSearch'
+import { AssetModelSelectWithSearch } from '../goodsreceipt/AssetModelSelectWithSearch'
+import { UomSelectWithSearch } from '../goodsreceipt/UomSelectWithSearch'
+import { toast } from 'sonner'
+
+const translations = {
+  en: {
+    backToList: 'Back to Goods Issue List',
+    createIssue: 'Create Goods Issue',
+    issueHeader: 'Issue Header',
+    issueNo: 'Issue No',
+    issueType: 'Issue Type',
+    reference: 'Reference',
+    partner: 'Partner',
+    sourceWarehouse: 'Source Warehouse',
+    destinationWarehouse: 'Destination Warehouse',
+    plannedDate: 'Planned Date',
+    remarks: 'Remarks',
+    issueLines: 'Issue Lines',
+    addLine: 'Add Line',
+    importLines: 'Import Lines',
+    exportLines: 'Export Lines',
+    assetModel: 'Asset Model',
+    unitOfMeasure: 'Unit of Measure',
+    trackingType: 'Tracking Type',
+    plannedQty: 'Planned Qty',
+    lineNote: 'Line Note',
+    details: 'Details',
+    remove: 'Remove',
+    noLines: 'No lines added yet. Use Add Line or import from template.',
+    saveDraft: 'Save Draft',
+    cancel: 'Cancel',
+    draftStatus: 'Draft',
+    detailTitle: 'Tracking Details',
+    serialHelp: 'Enter one serial per line. Empty lines will be ignored.',
+    lotHelp: 'Provide lot number and manufacturing / expiration dates when available.',
+    partnerRequired: 'Partner is required for Sales Order and Return issues.',
+    destinationRequired: 'Destination warehouse is required for Transfer issues.',
+    sourceRequired: 'Source warehouse is required.',
+    referenceRequired: 'Reference is required for Sales Order, Transfer and Return issues.',
+    quantityRequired: 'Quantity must be greater than 0.',
+    minimumOneLine: 'At least one line is required.',
+    draftSaved: 'Goods issue saved as draft successfully.',
+    SO: 'Sales Order',
+    Transfer: 'Transfer',
+    Return: 'Return',
+    Consumption: 'Consumption'
+  },
+  vn: {
+    backToList: 'Quay lại danh sách phiếu xuất',
+    createIssue: 'Tạo phiếu xuất kho',
+    issueHeader: 'Thông tin phiếu',
+    issueNo: 'Số phiếu',
+    issueType: 'Loại phiếu',
+    reference: 'Tham chiếu',
+    partner: 'Đối tác',
+    sourceWarehouse: 'Kho xuất',
+    destinationWarehouse: 'Kho nhận',
+    plannedDate: 'Ngày dự kiến',
+    remarks: 'Ghi chú',
+    issueLines: 'Chi tiết phiếu',
+    addLine: 'Thêm dòng',
+    importLines: 'Nhập dòng',
+    exportLines: 'Xuất dòng',
+    assetModel: 'Mẫu tài sản',
+    unitOfMeasure: 'Đơn vị tính',
+    trackingType: 'Loại theo dõi',
+    plannedQty: 'SL dự kiến',
+    lineNote: 'Ghi chú dòng',
+    details: 'Chi tiết',
+    remove: 'Xóa',
+    noLines: 'Chưa có dòng nào. Sử dụng Thêm dòng hoặc nhập từ file.',
+    saveDraft: 'Lưu nháp',
+    cancel: 'Hủy',
+    draftStatus: 'Nháp',
+    detailTitle: 'Thông tin theo dõi',
+    serialHelp: 'Nhập mỗi serial trên một dòng. Bỏ qua dòng trống.',
+    lotHelp: 'Cung cấp số lô và ngày sản xuất / hết hạn nếu có.',
+    partnerRequired: 'Đối tác bắt buộc cho phiếu bán hàng và trả hàng.',
+    destinationRequired: 'Kho nhận bắt buộc cho phiếu chuyển kho.',
+    sourceRequired: 'Vui lòng chọn kho xuất.',
+    referenceRequired: 'Tham chiếu bắt buộc cho phiếu bán hàng, chuyển kho và trả hàng.',
+    quantityRequired: 'Số lượng phải lớn hơn 0.',
+    minimumOneLine: 'Cần ít nhất một dòng.',
+    draftSaved: 'Lưu phiếu nháp thành công.',
+    SO: 'Đơn bán hàng',
+    Transfer: 'Chuyển kho',
+    Return: 'Trả hàng',
+    Consumption: 'Tiêu dùng nội bộ'
+  }
+}
+
+type DetailDialogState = {
+  index: number
+} | null
+
+const issueTypes: GoodsIssue['issue_type'][] = ['SO', 'Transfer', 'Return', 'Consumption']
+
+const requiresPartner = (issueType: GoodsIssue['issue_type']) =>
+  issueType === 'SO' || issueType === 'Return'
+
+const requiresDestinationWarehouse = (issueType: GoodsIssue['issue_type']) =>
+  issueType === 'Transfer'
+
+export function GoodsIssueFormWrapper() {
+  const { language } = useLanguage()
+  const t = translations[language]
+
+  const [issueNo, setIssueNo] = useState('')
+  const [detailDialog, setDetailDialog] = useState<DetailDialogState>(null)
+  const [serialInput, setSerialInput] = useState('')
+  const [lotInfo, setLotInfo] = useState({ lot_no: '', mfg_date: '', exp_date: '' })
+
+  const form = useForm<GoodsIssueFormData>({
+    defaultValues: {
+      issue_type: 'SO',
+      planned_date: new Date().toISOString().split('T')[0],
+      lines: []
+    }
+  })
+
+  const { control, handleSubmit, watch, setValue, getValues, resetField } = form
+  const { fields, append, remove, update } = useFieldArray({
+    control,
+    name: 'lines'
+  })
+
+  const issueType = watch('issue_type')
+  const fromWarehouseId = watch('from_wh_id')
+
+  useEffect(() => {
+    if (!requiresPartner(issueType)) {
+      resetField('partner_id', { keepDirty: false })
+    }
+    if (!requiresDestinationWarehouse(issueType)) {
+      resetField('to_wh_id', { keepDirty: false })
+    }
+  }, [issueType, resetField])
+
+  useEffect(() => {
+    if (detailDialog !== null) {
+      const currentLine = getValues(`lines.${detailDialog.index}`)
+      setSerialInput((currentLine.serial_numbers || []).join('\n'))
+      setLotInfo({
+        lot_no: currentLine.lot_no || '',
+        mfg_date: currentLine.mfg_date || '',
+        exp_date: currentLine.exp_date || ''
+      })
+    }
+  }, [detailDialog, getValues])
+
+  const handleBack = () => {
+    window.location.hash = '#warehouse/goods-issue'
+  }
+
+  const handleAddLine = () => {
+    append({
+      model_id: '',
+      uom_id: '',
+      tracking_type: 'None',
+      qty_planned: 1,
+      note: ''
+    })
+  }
+
+  const handleModelChange = (index: number, modelId: string) => {
+    const model = mockModelAssets.find(m => m.id === modelId)
+    setValue(`lines.${index}.model_id`, modelId)
+    const tracking = (model?.tracking_type || 'None') as GoodsIssueTrackingType
+    setValue(`lines.${index}.tracking_type`, tracking)
+
+    if (tracking === 'Serial') {
+      setValue(`lines.${index}.serial_numbers`, [])
+    } else {
+      setValue(`lines.${index}.serial_numbers`, undefined)
+    }
+
+    if (tracking !== 'Lot') {
+      setValue(`lines.${index}.lot_no`, undefined)
+      setValue(`lines.${index}.mfg_date`, undefined)
+      setValue(`lines.${index}.exp_date`, undefined)
+    }
+
+    const defaultUom = model ? mockUoMs.find(u => u.uom_code === model.uom_code) : undefined
+    if (defaultUom) {
+      setValue(`lines.${index}.uom_id`, defaultUom.id)
+    }
+  }
+
+  const openDetailDialog = (index: number) => {
+    setDetailDialog({ index })
+  }
+
+  const closeDetailDialog = () => {
+    setDetailDialog(null)
+  }
+
+  const handleDetailSave = () => {
+    if (detailDialog === null) return
+    const currentLine = getValues(`lines.${detailDialog.index}`)
+    const updatedLine = { ...currentLine }
+
+    if (currentLine.tracking_type === 'Serial') {
+      const serials = serialInput
+        .split(/\r?\n/)
+        .map(serial => serial.trim())
+        .filter(Boolean)
+      updatedLine.serial_numbers = serials
+    }
+
+    if (currentLine.tracking_type === 'Lot') {
+      updatedLine.lot_no = lotInfo.lot_no || undefined
+      updatedLine.mfg_date = lotInfo.mfg_date || undefined
+      updatedLine.exp_date = lotInfo.exp_date || undefined
+    }
+
+    update(detailDialog.index, updatedLine)
+    closeDetailDialog()
+  }
+
+  const handleExportLines = () => {
+    const currentLines = getValues('lines')
+    logGoodsIssueAudit('exported', issueNo || 'draft', 'Goods issue line export placeholder', {
+      line_count: currentLines.length
+    })
+  }
+
+  const handleImportLines = () => {
+    logGoodsIssueAudit('imported', issueNo || 'draft', 'Goods issue line import placeholder')
+  }
+
+  const onSubmit = (data: GoodsIssueFormData) => {
+    const errors: string[] = []
+
+    if (!data.from_wh_id) {
+      errors.push(t.sourceRequired)
+    }
+
+    if (requiresPartner(data.issue_type) && !data.partner_id) {
+      errors.push(t.partnerRequired)
+    }
+
+    if (requiresDestinationWarehouse(data.issue_type) && !data.to_wh_id) {
+      errors.push(t.destinationRequired)
+    }
+
+    if ((data.issue_type === 'SO' || data.issue_type === 'Transfer' || data.issue_type === 'Return') && !data.ref_no) {
+      errors.push(t.referenceRequired)
+    }
+
+    if (!data.lines.length) {
+      errors.push(t.minimumOneLine)
+    }
+
+    const invalidQty = data.lines.some(line => !line.qty_planned || line.qty_planned <= 0)
+    if (invalidQty) {
+      errors.push(t.quantityRequired)
+    }
+
+    if (errors.length) {
+      alert(errors.join('\n'))
+      return
+    }
+
+    const fromWarehouse = mockWarehouses.find(w => w.id === data.from_wh_id)
+    const toWarehouse = data.to_wh_id ? mockWarehouses.find(w => w.id === data.to_wh_id) : undefined
+    const partner = data.partner_id ? mockPartners.find(p => p.id === data.partner_id) : undefined
+
+    let currentIssueNo = issueNo
+    if (!currentIssueNo) {
+      currentIssueNo = generateGoodsIssueNumber(fromWarehouse?.code || 'WH01')
+      setIssueNo(currentIssueNo)
+    }
+
+    const now = new Date().toISOString()
+
+    const newIssue: GoodsIssue = {
+      id: `gi-${Date.now()}`,
+      issue_no: currentIssueNo,
+      issue_type: data.issue_type,
+      ref_no: data.ref_no,
+      partner_id: data.partner_id,
+      partner_code: partner?.partner_code,
+      partner_name: partner?.partner_name,
+      from_wh_id: data.from_wh_id,
+      from_wh_code: fromWarehouse?.code || '',
+      from_wh_name: fromWarehouse?.name || '',
+      to_wh_id: data.to_wh_id,
+      to_wh_code: toWarehouse?.code,
+      to_wh_name: toWarehouse?.name,
+      planned_date: data.planned_date,
+      remark: data.remark,
+      status: 'Draft',
+      lines: data.lines.map((line, index) => {
+        const model = mockModelAssets.find(m => m.id === line.model_id)
+        const uom = mockUoMs.find(u => u.id === line.uom_id)
+        return enrichGoodsIssueLine({
+          id: `gi-line-${Date.now()}-${index}`,
+          model_id: line.model_id,
+          model_code: model?.model_code || '',
+          model_name: model?.model_name || '',
+          uom_id: line.uom_id,
+          uom_code: uom?.uom_code || '',
+          uom_name: uom?.uom_name || '',
+          tracking_type: line.tracking_type,
+          qty_planned: line.qty_planned,
+          note: line.note,
+          serial_numbers: line.serial_numbers,
+          lot_no: line.lot_no,
+          mfg_date: line.mfg_date,
+          exp_date: line.exp_date
+        })
+      }),
+      created_at: now,
+      created_by: 'current_user',
+      updated_at: now,
+      updated_by: 'current_user'
+    }
+
+    logGoodsIssueAudit('created', newIssue.id, 'Goods issue draft created', {
+      issue_no: newIssue.issue_no,
+      issue_type: newIssue.issue_type
+    })
+    saveGoodsIssueDraft(newIssue)
+    toast.success(t.draftSaved)
+
+    setTimeout(() => {
+      window.location.hash = '#warehouse/goods-issue'
+    }, 1200)
+  }
+
+  const selectedLines = useMemo(() => fields, [fields])
+
+  const activeLine = detailDialog !== null ? getValues(`lines.${detailDialog.index}`) : null
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleBack}
+          className="flex items-center gap-2"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          {t.backToList}
+        </Button>
+        <div className="flex items-center gap-3">
+          <div>
+            <h1>{t.createIssue}</h1>
+            {issueNo && (
+              <p className="text-muted-foreground font-mono">{issueNo}</p>
+            )}
+          </div>
+          <Badge variant="outline">{t.draftStatus}</Badge>
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>{t.issueHeader}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label>{t.issueType}</Label>
+                <Controller
+                  control={control}
+                  name="issue_type"
+                  render={({ field }) => (
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <SelectTrigger>
+                        <SelectValue placeholder={t.issueType} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {issueTypes.map(type => (
+                          <SelectItem key={type} value={type}>
+                            {t[type]}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>{t.reference}</Label>
+                <Controller
+                  control={control}
+                  name="ref_no"
+                  render={({ field }) => (
+                    <Input {...field} placeholder={t.reference} />
+                  )}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>{t.partner}</Label>
+                <Controller
+                  control={control}
+                  name="partner_id"
+                  render={({ field }) => (
+                    <Select
+                      value={field.value || ''}
+                      onValueChange={(value) => field.onChange(value || undefined)}
+                      disabled={!requiresPartner(issueType)}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder={t.partner} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="">—</SelectItem>
+                        {mockPartners.map(partner => (
+                          <SelectItem key={partner.id} value={partner.id}>
+                            {partner.partner_name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>{t.plannedDate}</Label>
+                <Controller
+                  control={control}
+                  name="planned_date"
+                  render={({ field }) => (
+                    <Input type="date" {...field} />
+                  )}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>{t.sourceWarehouse}</Label>
+                <Controller
+                  control={control}
+                  name="from_wh_id"
+                  render={({ field }) => (
+                    <WarehouseSelectWithSearch
+                      value={field.value}
+                      onValueChange={field.onChange}
+                    />
+                  )}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>{t.destinationWarehouse}</Label>
+                <Controller
+                  control={control}
+                  name="to_wh_id"
+                  render={({ field }) => (
+                    <WarehouseSelectWithSearch
+                      value={field.value}
+                      onValueChange={field.onChange}
+                      excludeWarehouseId={fromWarehouseId}
+                      disabled={!requiresDestinationWarehouse(issueType)}
+                    />
+                  )}
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>{t.remarks}</Label>
+              <Controller
+                control={control}
+                name="remark"
+                render={({ field }) => (
+                  <Textarea {...field} rows={3} placeholder={t.remarks} />
+                )}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <CardTitle>{t.issueLines}</CardTitle>
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" variant="outline" size="sm" onClick={handleImportLines} className="flex items-center gap-2">
+                <Upload className="h-4 w-4" />
+                {t.importLines}
+              </Button>
+              <Button type="button" variant="outline" size="sm" onClick={handleExportLines} className="flex items-center gap-2">
+                <Download className="h-4 w-4" />
+                {t.exportLines}
+              </Button>
+              <Button type="button" size="sm" onClick={handleAddLine} className="flex items-center gap-2">
+                <Plus className="h-4 w-4" />
+                {t.addLine}
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {selectedLines.length === 0 ? (
+              <p className="text-sm text-muted-foreground">{t.noLines}</p>
+            ) : (
+              selectedLines.map((field, index) => (
+                <div key={field.id} className="border rounded-lg p-4 space-y-3">
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label>{t.assetModel}</Label>
+                      <Controller
+                        control={control}
+                        name={`lines.${index}.model_id`}
+                        render={({ field }) => (
+                          <AssetModelSelectWithSearch
+                            value={field.value}
+                            onValueChange={(value) => {
+                              field.onChange(value)
+                              handleModelChange(index, value)
+                            }}
+                          />
+                        )}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label>{t.unitOfMeasure}</Label>
+                      <Controller
+                        control={control}
+                        name={`lines.${index}.uom_id`}
+                        render={({ field }) => (
+                          <UomSelectWithSearch
+                            value={field.value}
+                            onValueChange={field.onChange}
+                          />
+                        )}
+                      />
+                    </div>
+                  </div>
+                  <div className="grid gap-3 md:grid-cols-[1fr,1fr,auto] md:items-end">
+                    <div className="space-y-2">
+                      <Label>{t.trackingType}</Label>
+                      <Controller
+                        control={control}
+                        name={`lines.${index}.tracking_type`}
+                        render={({ field }) => (
+                          <Input value={field.value} readOnly className="bg-muted" />
+                        )}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label>{t.plannedQty}</Label>
+                      <Controller
+                        control={control}
+                        name={`lines.${index}.qty_planned`}
+                        render={({ field }) => (
+                          <Input
+                            type="number"
+                            min={1}
+                            {...field}
+                            value={field.value ?? ''}
+                            onChange={(event) => {
+                              const value = event.target.value
+                              field.onChange(value === '' ? undefined : Number(value))
+                            }}
+                          />
+                        )}
+                      />
+                    </div>
+                    <div className="flex gap-2">
+                      <Button type="button" variant="outline" onClick={() => openDetailDialog(index)} className="flex items-center gap-2">
+                        <Info className="h-4 w-4" />
+                        {t.details}
+                      </Button>
+                      <Button type="button" variant="ghost" onClick={() => remove(index)} className="text-destructive">
+                        <Trash2 className="h-4 w-4" />
+                        <span className="sr-only">{t.remove}</span>
+                      </Button>
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <Label>{t.lineNote}</Label>
+                    <Controller
+                      control={control}
+                      name={`lines.${index}.note`}
+                      render={({ field }) => (
+                        <Textarea {...field} rows={2} />
+                      )}
+                    />
+                  </div>
+                </div>
+              ))
+            )}
+          </CardContent>
+        </Card>
+
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" onClick={handleBack}>
+            {t.cancel}
+          </Button>
+          <Button type="submit" className="flex items-center gap-2">
+            <Save className="h-4 w-4" />
+            {t.saveDraft}
+          </Button>
+        </div>
+      </form>
+
+      <Dialog open={detailDialog !== null} onOpenChange={(open) => !open && closeDetailDialog()}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t.detailTitle}</DialogTitle>
+            <DialogDescription>
+              {activeLine?.tracking_type === 'Serial' ? t.serialHelp : activeLine?.tracking_type === 'Lot' ? t.lotHelp : ''}
+            </DialogDescription>
+          </DialogHeader>
+          {activeLine && (
+            <div className="space-y-4">
+              <div className="space-y-1">
+                <Label>{t.trackingType}</Label>
+                <Input value={activeLine.tracking_type} readOnly className="bg-muted" />
+              </div>
+              {activeLine.tracking_type === 'Serial' && (
+                <div className="space-y-2">
+                  <Label>Serials</Label>
+                  <Textarea
+                    rows={6}
+                    value={serialInput}
+                    onChange={(event) => setSerialInput(event.target.value)}
+                  />
+                </div>
+              )}
+              {activeLine.tracking_type === 'Lot' && (
+                <div className="grid gap-3 md:grid-cols-3">
+                  <div className="space-y-2">
+                    <Label>Lot No</Label>
+                    <Input
+                      value={lotInfo.lot_no}
+                      onChange={(event) => setLotInfo(info => ({ ...info, lot_no: event.target.value }))}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>MFG Date</Label>
+                    <Input
+                      type="date"
+                      value={lotInfo.mfg_date}
+                      onChange={(event) => setLotInfo(info => ({ ...info, mfg_date: event.target.value }))}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>EXP Date</Label>
+                    <Input
+                      type="date"
+                      value={lotInfo.exp_date}
+                      onChange={(event) => setLotInfo(info => ({ ...info, exp_date: event.target.value }))}
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+          <DialogFooter className="mt-4 flex gap-2 justify-end">
+            <Button type="button" variant="outline" onClick={closeDetailDialog}>
+              {t.cancel}
+            </Button>
+            <Button type="button" onClick={handleDetailSave}>
+              {t.saveDraft}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/src/components/goodsissue/GoodsIssueManagement.tsx
+++ b/src/components/goodsissue/GoodsIssueManagement.tsx
@@ -1,0 +1,182 @@
+import { useMemo, useRef, useState } from 'react'
+import { Plus, Upload, Download } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
+import { Button } from '../ui/button'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table'
+import { Badge } from '../ui/badge'
+import { useLanguage } from '../../contexts/LanguageContext'
+import { logGoodsIssueAudit, mockGoodsIssues, resolveIssueHeaderData } from '../../data/mockGoodsIssueData'
+import { GoodsIssue } from '../../types/goodsIssue'
+
+const translations = {
+  en: {
+    title: 'Goods Issue Management',
+    description: 'Review and control outbound inventory flows',
+    create: 'Create Issue',
+    import: 'Import',
+    export: 'Export',
+    issueNo: 'Issue No',
+    type: 'Type',
+    partner: 'Partner / Destination',
+    source: 'Source Warehouse',
+    plannedDate: 'Planned Date',
+    status: 'Status',
+    remark: 'Remark',
+    noIssues: 'No goods issues found',
+    SO: 'Sales Order',
+    Transfer: 'Transfer',
+    Return: 'Return',
+    Consumption: 'Consumption',
+    Draft: 'Draft',
+    Picking: 'Picking',
+    Submitted: 'Submitted',
+    Completed: 'Completed',
+    Cancelled: 'Cancelled'
+  },
+  vn: {
+    title: 'Quản Lý Phiếu Xuất Kho',
+    description: 'Theo dõi và kiểm soát hàng xuất kho',
+    create: 'Tạo Phiếu Xuất',
+    import: 'Nhập File',
+    export: 'Xuất File',
+    issueNo: 'Số Phiếu',
+    type: 'Loại',
+    partner: 'Đối Tác / Nơi Nhận',
+    source: 'Kho Xuất',
+    plannedDate: 'Ngày Dự Kiến',
+    status: 'Trạng Thái',
+    remark: 'Ghi Chú',
+    noIssues: 'Không có phiếu xuất kho',
+    SO: 'Đơn Bán Hàng',
+    Transfer: 'Chuyển Kho',
+    Return: 'Trả Hàng',
+    Consumption: 'Tiêu Dùng Nội Bộ',
+    Draft: 'Nháp',
+    Picking: 'Đang Lấy Hàng',
+    Submitted: 'Đã Gửi',
+    Completed: 'Hoàn Thành',
+    Cancelled: 'Đã Hủy'
+  }
+}
+
+const statusColors: Record<GoodsIssue['status'], string> = {
+  Draft: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200',
+  Picking: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+  Submitted: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+  Completed: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+  Cancelled: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
+}
+
+export function GoodsIssueManagement() {
+  const { language } = useLanguage()
+  const t = translations[language]
+  const [issues] = useState<GoodsIssue[]>(() =>
+    mockGoodsIssues.map(resolveIssueHeaderData)
+  )
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const formattedIssues = useMemo(() => issues, [issues])
+
+  const handleCreate = () => {
+    window.location.hash = '#warehouse/goods-issue/create'
+  }
+
+  const handleExport = () => {
+    logGoodsIssueAudit('exported', 'bulk', 'Goods issue export initiated', {
+      total_records: formattedIssues.length
+    })
+  }
+
+  const handleImportClick = () => {
+    fileInputRef.current?.click()
+  }
+
+  const handleImport = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (!file) return
+
+    logGoodsIssueAudit('imported', 'bulk', 'Goods issue import placeholder triggered', {
+      file_name: file.name,
+      file_size: file.size
+    })
+
+    event.target.value = ''
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <CardTitle>{t.title}</CardTitle>
+            <p className="text-muted-foreground text-sm">{t.description}</p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".csv,.xlsx"
+              className="hidden"
+              onChange={handleImport}
+            />
+            <Button variant="outline" onClick={handleImportClick} className="flex items-center gap-2">
+              <Upload className="h-4 w-4" />
+              {t.import}
+            </Button>
+            <Button variant="outline" onClick={handleExport} className="flex items-center gap-2">
+              <Download className="h-4 w-4" />
+              {t.export}
+            </Button>
+            <Button onClick={handleCreate} className="flex items-center gap-2">
+              <Plus className="h-4 w-4" />
+              {t.create}
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t.issueNo}</TableHead>
+                <TableHead>{t.type}</TableHead>
+                <TableHead>{t.partner}</TableHead>
+                <TableHead>{t.source}</TableHead>
+                <TableHead>{t.plannedDate}</TableHead>
+                <TableHead>{t.status}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {formattedIssues.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="text-center text-muted-foreground py-6">
+                    {t.noIssues}
+                  </TableCell>
+                </TableRow>
+              ) : (
+                formattedIssues.map(issue => (
+                  <TableRow key={issue.id}>
+                    <TableCell className="font-medium">{issue.issue_no}</TableCell>
+                    <TableCell>{t[issue.issue_type]}</TableCell>
+                    <TableCell>
+                      {issue.partner_name || issue.to_wh_name || '—'}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-col">
+                        <span>{issue.from_wh_name}</span>
+                        <span className="text-xs text-muted-foreground">{issue.from_wh_code}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell>{issue.planned_date}</TableCell>
+                    <TableCell>
+                      <Badge className={statusColors[issue.status]}>{t[issue.status]}</Badge>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/data/mockGoodsIssueData.ts
+++ b/src/data/mockGoodsIssueData.ts
@@ -1,0 +1,172 @@
+import { GoodsIssue, GoodsIssueAuditLog, GoodsIssueLine } from '../types/goodsIssue'
+import { mockModelAssets } from './mockModelAssetData'
+import { mockUoMs } from './mockUomData'
+import { mockWarehouses } from './mockWarehouseData'
+import { mockPartners } from './mockPartnerData'
+
+export const mockGoodsIssueLines: GoodsIssueLine[] = [
+  {
+    id: 'gi-line-1',
+    model_id: '1',
+    model_code: 'MD_001',
+    model_name: 'Dell OptiPlex 7090',
+    uom_id: '1',
+    uom_code: 'PCS',
+    uom_name: 'Pieces',
+    tracking_type: 'Serial',
+    qty_planned: 5,
+    serial_numbers: ['SN-0001', 'SN-0002', 'SN-0003', 'SN-0004', 'SN-0005'],
+    note: 'Demo serial tracked issue'
+  },
+  {
+    id: 'gi-line-2',
+    model_id: '3',
+    model_code: 'MD_003',
+    model_name: 'Office Chair Ergonomic',
+    uom_id: '1',
+    uom_code: 'PCS',
+    uom_name: 'Pieces',
+    tracking_type: 'None',
+    qty_planned: 20
+  },
+  {
+    id: 'gi-line-3',
+    model_id: '4',
+    model_code: 'MD_004',
+    model_name: 'Network Cable Cat6',
+    uom_id: '6',
+    uom_code: 'KG',
+    uom_name: 'Kilogram',
+    tracking_type: 'Lot',
+    qty_planned: 2,
+    lot_no: 'LOT-2024-DEC',
+    mfg_date: '2024-10-01',
+    exp_date: '2026-10-01'
+  }
+]
+
+export const mockGoodsIssues: GoodsIssue[] = [
+  {
+    id: 'gi-1',
+    issue_no: 'GI-WH01-0001',
+    issue_type: 'SO',
+    ref_no: 'SO-2024-001',
+    partner_id: '1',
+    partner_code: 'CUST001',
+    partner_name: 'Saigon Retail Group',
+    from_wh_id: '1',
+    from_wh_code: 'WH01',
+    from_wh_name: 'Main Warehouse',
+    planned_date: '2024-12-20',
+    remark: 'Priority order for key customer',
+    status: 'Draft',
+    lines: [mockGoodsIssueLines[0], mockGoodsIssueLines[1]],
+    created_at: '2024-12-10T09:00:00Z',
+    created_by: 'inventory_staff',
+    updated_at: '2024-12-10T09:00:00Z',
+    updated_by: 'inventory_staff'
+  },
+  {
+    id: 'gi-2',
+    issue_no: 'GI-WH02-0001',
+    issue_type: 'Transfer',
+    ref_no: 'TR-2024-014',
+    from_wh_id: '2',
+    from_wh_code: 'WH02',
+    from_wh_name: 'Branch Warehouse',
+    to_wh_id: '1',
+    to_wh_code: 'WH01',
+    to_wh_name: 'Main Warehouse',
+    planned_date: '2024-12-18',
+    remark: 'Replenish central stock',
+    status: 'Draft',
+    lines: [mockGoodsIssueLines[2]],
+    created_at: '2024-12-08T08:30:00Z',
+    created_by: 'warehouse_manager',
+    updated_at: '2024-12-08T08:30:00Z',
+    updated_by: 'warehouse_manager'
+  }
+]
+
+const goodsIssueSequences: Record<string, number> = {}
+
+mockGoodsIssues.forEach(issue => {
+  const whCode = issue.from_wh_code
+  if (!goodsIssueSequences[whCode]) {
+    goodsIssueSequences[whCode] = 0
+  }
+  const match = issue.issue_no.match(/GI-[^-]+-(\d+)/)
+  if (match) {
+    const seq = parseInt(match[1], 10)
+    goodsIssueSequences[whCode] = Math.max(goodsIssueSequences[whCode], seq)
+  }
+})
+
+export const mockGoodsIssueAuditLogs: GoodsIssueAuditLog[] = []
+
+export function generateGoodsIssueNumber(warehouseCode: string) {
+  const whCode = warehouseCode || 'WH01'
+  goodsIssueSequences[whCode] = (goodsIssueSequences[whCode] || 0) + 1
+  return `GI-${whCode}-${goodsIssueSequences[whCode].toString().padStart(4, '0')}`
+}
+
+export function logGoodsIssueAudit(action: GoodsIssueAuditLog['action'], issueId: string, details: string, metadata?: Record<string, unknown>) {
+  const entry: GoodsIssueAuditLog = {
+    id: `${Date.now()}`,
+    issue_id: issueId,
+    action,
+    user_id: 'current_user',
+    user_name: 'Current User',
+    timestamp: new Date().toISOString(),
+    details,
+    metadata
+  }
+
+  mockGoodsIssueAuditLogs.push(entry)
+  console.info('[Audit][GoodsIssue]', entry)
+}
+
+export function saveGoodsIssueDraft(draft: GoodsIssue) {
+  const index = mockGoodsIssues.findIndex(issue => issue.id === draft.id)
+  if (index >= 0) {
+    mockGoodsIssues[index] = draft
+  } else {
+    mockGoodsIssues.push(draft)
+  }
+
+  logGoodsIssueAudit('updated', draft.id, 'Goods issue draft saved', {
+    issue_no: draft.issue_no,
+    status: draft.status,
+    line_count: draft.lines.length
+  })
+}
+
+export function resolveIssueHeaderData(issue: GoodsIssue) {
+  const fromWarehouse = mockWarehouses.find(w => w.id === issue.from_wh_id)
+  const toWarehouse = issue.to_wh_id ? mockWarehouses.find(w => w.id === issue.to_wh_id) : undefined
+  const partner = issue.partner_id ? mockPartners.find(p => p.id === issue.partner_id) : undefined
+
+  return {
+    ...issue,
+    from_wh_code: fromWarehouse?.code || issue.from_wh_code,
+    from_wh_name: fromWarehouse?.name || issue.from_wh_name,
+    to_wh_code: toWarehouse?.code || issue.to_wh_code,
+    to_wh_name: toWarehouse?.name || issue.to_wh_name,
+    partner_code: partner?.partner_code || issue.partner_code,
+    partner_name: partner?.partner_name || issue.partner_name
+  }
+}
+
+export function enrichGoodsIssueLine(line: GoodsIssueLine): GoodsIssueLine {
+  const model = mockModelAssets.find(m => m.id === line.model_id)
+  const uom = mockUoMs.find(u => u.id === line.uom_id)
+
+  return {
+    ...line,
+    model_code: model?.model_code || line.model_code,
+    model_name: model?.model_name || line.model_name,
+    tracking_type: (model?.tracking_type as GoodsIssueLine['tracking_type']) || line.tracking_type,
+    uom_code: uom?.uom_code || line.uom_code,
+    uom_name: uom?.uom_name || line.uom_name
+  }
+}

--- a/src/types/goodsIssue.ts
+++ b/src/types/goodsIssue.ts
@@ -1,0 +1,76 @@
+export type GoodsIssueTrackingType = 'None' | 'Lot' | 'Serial'
+
+export interface GoodsIssueLine {
+  id: string
+  model_id: string
+  model_code: string
+  model_name: string
+  uom_id: string
+  uom_code: string
+  uom_name: string
+  tracking_type: GoodsIssueTrackingType
+  qty_planned: number
+  note?: string
+  serial_numbers?: string[]
+  lot_no?: string
+  mfg_date?: string
+  exp_date?: string
+}
+
+export interface GoodsIssue {
+  id: string
+  issue_no: string
+  issue_type: 'SO' | 'Transfer' | 'Return' | 'Consumption'
+  ref_no?: string
+  partner_id?: string
+  partner_code?: string
+  partner_name?: string
+  from_wh_id: string
+  from_wh_code: string
+  from_wh_name: string
+  to_wh_id?: string
+  to_wh_code?: string
+  to_wh_name?: string
+  planned_date: string
+  remark?: string
+  status: 'Draft' | 'Picking' | 'Submitted' | 'Completed' | 'Cancelled'
+  lines: GoodsIssueLine[]
+  created_at: string
+  created_by: string
+  updated_at: string
+  updated_by: string
+}
+
+export interface GoodsIssueFormLine {
+  model_id: string
+  uom_id: string
+  tracking_type: GoodsIssueTrackingType
+  qty_planned: number
+  note?: string
+  serial_numbers?: string[]
+  lot_no?: string
+  mfg_date?: string
+  exp_date?: string
+}
+
+export interface GoodsIssueFormData {
+  issue_type: 'SO' | 'Transfer' | 'Return' | 'Consumption'
+  ref_no?: string
+  partner_id?: string
+  from_wh_id: string
+  to_wh_id?: string
+  planned_date: string
+  remark?: string
+  lines: GoodsIssueFormLine[]
+}
+
+export interface GoodsIssueAuditLog {
+  id: string
+  issue_id: string
+  action: 'created' | 'updated' | 'exported' | 'imported'
+  user_id: string
+  user_name: string
+  timestamp: string
+  details: string
+  metadata?: Record<string, unknown>
+}


### PR DESCRIPTION
## Summary
- add goods issue routing and management screen with audit logging hooks
- implement draft goods issue form with validation, tracking detail dialog, and GI number generation
- seed mock data and helpers for goods issues

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca7613365c8325810c5cc1075d4fd4