### PR TITLE
feat: add goods issue grid totals and filters

### DIFF
--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -3,6 +3,7 @@ import { MainContent } from './MainContent'
 import { OrganizationManagement } from './organization/OrganizationManagement'
 import { BranchManagement } from './branch/BranchManagement'
 import { WarehouseManagement } from './warehouse/WarehouseManagement'
+import { GoodsIssueManagement } from './warehouse/GoodsIssueManagement'
 import { LocationManagement } from './location/LocationManagement'
 import { UoMManagement } from './uom/UoMManagement'
 import { PartnerManagement } from './partner/PartnerManagement'
@@ -27,6 +28,7 @@ type RouteKey =
   | 'modelasset'
   | 'stockonhand'
   | 'goodsreceipt'
+  | 'goodsissue'
   | 'goodsreceipt/create'
   | 'goodsreceipt/edit'
   | 'goodsreceipt/view'
@@ -59,6 +61,8 @@ export function Router({ currentRoute }: RouterProps) {
       return <StockOnhandManagement />
     case 'goodsreceipt':
       return <GoodsReceiptManagement />
+    case 'goodsissue':
+      return <GoodsIssueManagement />
     case 'goodsreceipt/create':
       return <GoodsReceiptFormWrapper mode="create" />
     case 'goodsreceipt/edit':
@@ -104,6 +108,7 @@ export const useRouter = () => {
         'assets/modelasset': 'modelasset',
         'warehouse/stock-onhand': 'stockonhand',
         'warehouse/goods-receipt': 'goodsreceipt',
+        'warehouse/goods-issue': 'goodsissue',
         'warehouse/goods-receipt/create': 'goodsreceipt/create',
         'warehouse/goods-receipt/edit': 'goodsreceipt/edit',
         'warehouse/goods-receipt/view': 'goodsreceipt/view',
@@ -137,6 +142,7 @@ export const useRouter = () => {
       'modelasset': '#assets/modelasset',
       'stockonhand': '#warehouse/stock-onhand',
       'goodsreceipt': '#warehouse/goods-receipt',
+      'goodsissue': '#warehouse/goods-issue',
       'goodsreceipt/create': '#warehouse/goods-receipt/create',
       'goodsreceipt/edit': '#warehouse/goods-receipt/edit',
       'goodsreceipt/view': '#warehouse/goods-receipt/view',

--- a/src/components/warehouse/GoodsIssueManagement.tsx
+++ b/src/components/warehouse/GoodsIssueManagement.tsx
@@ -1,0 +1,315 @@
+import { useMemo, useState } from 'react'
+import { Search, Filter } from 'lucide-react'
+
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table'
+import { Badge } from '../ui/badge'
+
+import { mockGoodsIssues } from '../../data/mockGoodsIssueData'
+import { GoodsIssue } from '../../types/goodsIssue'
+import { useLanguage } from '../../contexts/LanguageContext'
+
+const statusColors: Record<GoodsIssue['status'], string> = {
+  Draft: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200',
+  Picking: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+  Picked: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+  Completed: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+  Cancelled: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
+}
+
+const translations = {
+  en: {
+    title: 'Goods Issue Management',
+    description: 'Review and manage goods issues, monitor picking progress, and track fulfillment accuracy.',
+    searchPlaceholder: 'Search GI number, partner or warehouse...',
+    statusFilter: 'Status',
+    typeFilter: 'Type',
+    expectedDateFilter: 'Expected Date',
+    startDate: 'Start Date',
+    endDate: 'End Date',
+    clearFilters: 'Clear Filters',
+    issueNo: 'GI Number',
+    issueType: 'Type',
+    partner: 'Partner / Destination',
+    fromWarehouse: 'From Warehouse',
+    toWarehouse: 'To Warehouse',
+    expectedDate: 'Expected Date',
+    status: 'Status',
+    totalPlanned: 'Total Planned',
+    totalPicked: 'Total Picked',
+    totalDiff: 'Difference',
+    createdAt: 'Created At',
+    createdBy: 'Created By',
+    summaryTotals: (planned: number, picked: number, diff: number) =>
+      `Planned: ${planned.toLocaleString()} • Picked: ${picked.toLocaleString()} • Diff: ${diff.toLocaleString()}`,
+    noResults: 'No goods issues found'
+  },
+  vn: {
+    title: 'Quản Lý Phiếu Xuất Kho',
+    description: 'Theo dõi phiếu xuất kho, tình trạng soạn hàng và độ chính xác thực hiện.',
+    searchPlaceholder: 'Tìm số phiếu, đối tác hoặc kho...',
+    statusFilter: 'Trạng thái',
+    typeFilter: 'Loại',
+    expectedDateFilter: 'Ngày dự kiến',
+    startDate: 'Từ ngày',
+    endDate: 'Đến ngày',
+    clearFilters: 'Xóa lọc',
+    issueNo: 'Số phiếu',
+    issueType: 'Loại',
+    partner: 'Đối tác / Điểm đến',
+    fromWarehouse: 'Kho xuất',
+    toWarehouse: 'Kho nhận',
+    expectedDate: 'Ngày dự kiến',
+    status: 'Trạng thái',
+    totalPlanned: 'Tổng kế hoạch',
+    totalPicked: 'Tổng đã soạn',
+    totalDiff: 'Chênh lệch',
+    createdAt: 'Ngày tạo',
+    createdBy: 'Người tạo',
+    summaryTotals: (planned: number, picked: number, diff: number) =>
+      `Kế hoạch: ${planned.toLocaleString()} • Đã soạn: ${picked.toLocaleString()} • Chênh: ${diff.toLocaleString()}`,
+    noResults: 'Không có phiếu xuất kho'
+  }
+}
+
+const formatDate = (dateString: string, withTime = false) => {
+  const date = new Date(dateString)
+  if (Number.isNaN(date.getTime())) {
+    return dateString
+  }
+
+  return withTime
+    ? date.toLocaleString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit'
+      })
+    : date.toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: '2-digit'
+      })
+}
+
+const calculateTotals = (issue: GoodsIssue) => {
+  return issue.lines.reduce(
+    (acc, line) => {
+      acc.planned += line.planned_qty
+      acc.picked += line.picked_qty
+      return acc
+    },
+    { planned: 0, picked: 0 }
+  )
+}
+
+export function GoodsIssueManagement() {
+  const { language } = useLanguage()
+  const [issues] = useState<GoodsIssue[]>(mockGoodsIssues)
+  const [searchTerm, setSearchTerm] = useState('')
+  const [statusFilter, setStatusFilter] = useState<string>('all')
+  const [typeFilter, setTypeFilter] = useState<string>('all')
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+
+  const selectedLanguage: keyof typeof translations = language in translations ? language : 'en'
+  const t = translations[selectedLanguage]
+
+  const uniqueStatuses = useMemo(
+    () => Array.from(new Set(issues.map(issue => issue.status))),
+    [issues]
+  )
+  const uniqueTypes = useMemo(
+    () => Array.from(new Set(issues.map(issue => issue.issue_type))),
+    [issues]
+  )
+
+  const filteredIssues = useMemo(() => {
+    return issues.filter(issue => {
+      const search = searchTerm.trim().toLowerCase()
+
+      const matchesSearch =
+        !search ||
+        issue.issue_no.toLowerCase().includes(search) ||
+        issue.partner_name?.toLowerCase().includes(search) ||
+        issue.from_wh_name.toLowerCase().includes(search) ||
+        issue.to_wh_name?.toLowerCase().includes(search) ||
+        issue.created_by.toLowerCase().includes(search)
+
+      const matchesStatus = statusFilter === 'all' || issue.status === statusFilter
+      const matchesType = typeFilter === 'all' || issue.issue_type === typeFilter
+
+      let matchesDate = true
+      if (startDate && endDate) {
+        const issueDate = new Date(issue.expected_date)
+        const start = new Date(startDate)
+        const end = new Date(endDate)
+        matchesDate = issueDate >= start && issueDate <= end
+      } else if (startDate) {
+        const issueDate = new Date(issue.expected_date)
+        const start = new Date(startDate)
+        matchesDate = issueDate >= start
+      } else if (endDate) {
+        const issueDate = new Date(issue.expected_date)
+        const end = new Date(endDate)
+        matchesDate = issueDate <= end
+      }
+
+      return matchesSearch && matchesStatus && matchesType && matchesDate
+    })
+  }, [issues, searchTerm, statusFilter, typeFilter, startDate, endDate])
+
+  const clearFilters = () => {
+    setSearchTerm('')
+    setStatusFilter('all')
+    setTypeFilter('all')
+    setStartDate('')
+    setEndDate('')
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="pb-4">
+          <CardTitle className="text-2xl font-semibold">{t.title}</CardTitle>
+          <p className="text-sm text-muted-foreground">{t.description}</p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex w-full items-center gap-2 lg:w-72">
+              <Search className="h-4 w-4 text-muted-foreground" />
+              <Input
+                value={searchTerm}
+                onChange={event => setSearchTerm(event.target.value)}
+                placeholder={t.searchPlaceholder}
+              />
+            </div>
+            <div className="flex w-full flex-col gap-3 lg:w-auto lg:flex-row lg:items-center">
+              <div className="flex items-center gap-2">
+                <Filter className="hidden h-4 w-4 text-muted-foreground lg:block" />
+                <Select value={statusFilter} onValueChange={setStatusFilter}>
+                  <SelectTrigger className="w-[160px]">
+                    <SelectValue placeholder={t.statusFilter}>
+                      {statusFilter === 'all' ? t.statusFilter : statusFilter}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">{t.statusFilter}</SelectItem>
+                    {uniqueStatuses.map(status => (
+                      <SelectItem key={status} value={status}>
+                        {status}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <Select value={typeFilter} onValueChange={setTypeFilter}>
+                <SelectTrigger className="w-[160px]">
+                  <SelectValue placeholder={t.typeFilter}>
+                    {typeFilter === 'all' ? t.typeFilter : typeFilter}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t.typeFilter}</SelectItem>
+                  {uniqueTypes.map(type => (
+                    <SelectItem key={type} value={type}>
+                      {type}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <div className="flex flex-col gap-1">
+                  <span className="text-xs font-medium text-muted-foreground">{t.startDate}</span>
+                  <Input type="date" value={startDate} onChange={event => setStartDate(event.target.value)} />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <span className="text-xs font-medium text-muted-foreground">{t.endDate}</span>
+                  <Input type="date" value={endDate} onChange={event => setEndDate(event.target.value)} />
+                </div>
+              </div>
+              <Button variant="outline" onClick={clearFilters}>
+                {t.clearFilters}
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="min-w-[200px]">{t.issueNo}</TableHead>
+                  <TableHead>{t.issueType}</TableHead>
+                  <TableHead className="min-w-[180px]">{t.partner}</TableHead>
+                  <TableHead className="min-w-[160px]">{t.fromWarehouse}</TableHead>
+                  <TableHead className="min-w-[160px]">{t.toWarehouse}</TableHead>
+                  <TableHead>{t.expectedDate}</TableHead>
+                  <TableHead>{t.status}</TableHead>
+                  <TableHead className="text-right">{t.totalPlanned}</TableHead>
+                  <TableHead className="text-right">{t.totalPicked}</TableHead>
+                  <TableHead className="text-right">{t.totalDiff}</TableHead>
+                  <TableHead>{t.createdAt}</TableHead>
+                  <TableHead>{t.createdBy}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredIssues.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={12} className="py-8 text-center text-muted-foreground">
+                      {t.noResults}
+                    </TableCell>
+                  </TableRow>
+                )}
+
+                {filteredIssues.map(issue => {
+                  const totals = calculateTotals(issue)
+                  const difference = totals.picked - totals.planned
+
+                  return (
+                    <TableRow key={issue.issue_no}>
+                      <TableCell>
+                        <div className="flex flex-col gap-1">
+                          <span className="font-medium">{issue.issue_no}</span>
+                          <span className="text-xs text-muted-foreground">
+                            {t.summaryTotals(totals.planned, totals.picked, difference)}
+                          </span>
+                        </div>
+                      </TableCell>
+                      <TableCell>{issue.issue_type}</TableCell>
+                      <TableCell>
+                        <div className="flex flex-col">
+                          <span>{issue.partner_name || '—'}</span>
+                        </div>
+                      </TableCell>
+                      <TableCell>{issue.from_wh_name}</TableCell>
+                      <TableCell>{issue.to_wh_name || '—'}</TableCell>
+                      <TableCell>{formatDate(issue.expected_date)}</TableCell>
+                      <TableCell>
+                        <Badge className={statusColors[issue.status]}>{issue.status}</Badge>
+                      </TableCell>
+                      <TableCell className="text-right">{totals.planned.toLocaleString()}</TableCell>
+                      <TableCell className="text-right">{totals.picked.toLocaleString()}</TableCell>
+                      <TableCell className={`text-right ${difference !== 0 ? 'text-red-500 dark:text-red-400' : ''}`}>
+                        {difference.toLocaleString()}
+                      </TableCell>
+                      <TableCell>{formatDate(issue.created_at, true)}</TableCell>
+                      <TableCell>{issue.created_by}</TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/data/mockGoodsIssueData.ts
+++ b/src/data/mockGoodsIssueData.ts
@@ -1,0 +1,133 @@
+import { GoodsIssue } from '../types/goodsIssue'
+
+export const mockGoodsIssues: GoodsIssue[] = [
+  {
+    issue_no: 'GI-2024-001',
+    issue_type: 'Sales Order',
+    status: 'Picking',
+    partner_name: 'Acme Retailers',
+    from_wh_name: 'Central WH',
+    to_wh_name: 'Acme - District 1',
+    expected_date: '2024-06-18',
+    created_at: '2024-06-15T08:42:00Z',
+    created_by: 'Nguyen Van A',
+    lines: [
+      {
+        line_id: '1',
+        sku: 'SKU-1001',
+        product_name: 'Arabica Coffee Beans 1kg',
+        planned_qty: 120,
+        picked_qty: 115,
+        uom: 'bag'
+      },
+      {
+        line_id: '2',
+        sku: 'SKU-1045',
+        product_name: 'Premium Tea Blend 500g',
+        planned_qty: 80,
+        picked_qty: 80,
+        uom: 'box'
+      }
+    ]
+  },
+  {
+    issue_no: 'GI-2024-002',
+    issue_type: 'Transfer',
+    status: 'Picked',
+    partner_name: 'Internal Transfer',
+    from_wh_name: 'Central WH',
+    to_wh_name: 'Warehouse District 7',
+    expected_date: '2024-06-19',
+    created_at: '2024-06-14T10:10:00Z',
+    created_by: 'Tran Thi B',
+    lines: [
+      {
+        line_id: '1',
+        sku: 'SKU-2090',
+        product_name: 'Glass Bottles 330ml',
+        planned_qty: 500,
+        picked_qty: 500,
+        uom: 'pcs'
+      },
+      {
+        line_id: '2',
+        sku: 'SKU-3099',
+        product_name: 'Bottle Caps - Aluminum',
+        planned_qty: 500,
+        picked_qty: 498,
+        uom: 'pcs'
+      }
+    ]
+  },
+  {
+    issue_no: 'GI-2024-003',
+    issue_type: 'Sales Order',
+    status: 'Draft',
+    partner_name: 'Blue Ocean Supermarket',
+    from_wh_name: 'Warehouse District 7',
+    to_wh_name: 'Blue Ocean - Go Vap',
+    expected_date: '2024-06-22',
+    created_at: '2024-06-16T13:25:00Z',
+    created_by: 'Vo Hoang C',
+    lines: [
+      {
+        line_id: '1',
+        sku: 'SKU-4120',
+        product_name: 'Instant Noodles Spicy',
+        planned_qty: 300,
+        picked_qty: 0,
+        uom: 'case'
+      },
+      {
+        line_id: '2',
+        sku: 'SKU-4150',
+        product_name: 'Instant Noodles Chicken',
+        planned_qty: 300,
+        picked_qty: 0,
+        uom: 'case'
+      }
+    ]
+  },
+  {
+    issue_no: 'GI-2024-004',
+    issue_type: 'Manual',
+    status: 'Completed',
+    partner_name: 'Quality Disposal',
+    from_wh_name: 'Central WH',
+    to_wh_name: 'Scrap Yard',
+    expected_date: '2024-06-12',
+    created_at: '2024-06-10T09:05:00Z',
+    created_by: 'Le Thi D',
+    lines: [
+      {
+        line_id: '1',
+        sku: 'SKU-9001',
+        product_name: 'Expired Snack Packs',
+        planned_qty: 150,
+        picked_qty: 150,
+        uom: 'case'
+      }
+    ]
+  },
+  {
+    issue_no: 'GI-2024-005',
+    issue_type: 'Return',
+    status: 'Cancelled',
+    partner_name: 'Urban Mini Mart',
+    from_wh_name: 'Warehouse District 9',
+    to_wh_name: 'Vendor Returns',
+    expected_date: '2024-06-20',
+    created_at: '2024-06-17T07:12:00Z',
+    created_by: 'Nguyen Thanh E',
+    lines: [
+      {
+        line_id: '1',
+        sku: 'SKU-5200',
+        product_name: 'Yogurt Strawberry 6x100ml',
+        planned_qty: 200,
+        picked_qty: 0,
+        uom: 'pack'
+      }
+    ]
+  }
+]

--- a/src/types/goodsIssue.ts
+++ b/src/types/goodsIssue.ts
@@ -1,0 +1,21 @@
+export interface GoodsIssueLine {
+  line_id: string
+  sku: string
+  product_name: string
+  planned_qty: number
+  picked_qty: number
+  uom: string
+}
+
+export interface GoodsIssue {
+  issue_no: string
+  issue_type: 'Sales Order' | 'Transfer' | 'Return' | 'Manual'
+  status: 'Draft' | 'Picking' | 'Picked' | 'Completed' | 'Cancelled'
+  partner_name?: string
+  from_wh_name: string
+  to_wh_name?: string
+  expected_date: string
+  created_at: string
+  created_by: string
+  lines: GoodsIssueLine[]
+}


### PR DESCRIPTION
## Summary
- add a dedicated goods issue management grid with derived quantity totals and creation metadata
- surface partner/to warehouse information with a totals summary and status-aware badges
- support filtering by status, type, and expected date alongside search for GI numbers and partners

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca7818314c832599a2d78889464d6e