### PR TITLE
Fix translation lookup typing

### DIFF
--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -259,7 +259,9 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
   })
 
   const t = (key: string, params?: Record<string, string>): string => {
-    let translation = translations[language][key as keyof typeof translations[Language]] || key
+    const languageTranslations = translations[language] || translations.en
+    let translation =
+      languageTranslations[key as keyof typeof translations['en']] || key
     
     // Replace parameters in the translation string
     if (params && typeof translation === 'string') {


### PR DESCRIPTION
## Summary
- ensure the translation helper reads language entries using the active language key
- preserve parameter substitution on the resolved string

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca884eb2588325942cb2e1e0eb6675