### PR TITLE
Standardize Vietnamese language code

### DIFF
--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -73,9 +73,9 @@ export function DebugPanel() {
               English
             </Button>
             <Button 
-              variant={language === 'vn' ? 'default' : 'outline'}
+              variant={language === 'vi' ? 'default' : 'outline'}
               size="sm"
-              onClick={() => setLanguage('vn')}
+              onClick={() => setLanguage('vi')}
               className="flex items-center gap-2"
             >
               <Languages className="h-4 w-4" />

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -105,8 +105,8 @@ export function TopBar() {
                 {t('common.english')}
               </DropdownMenuItem>
               <DropdownMenuItem 
-                onClick={() => setLanguage('vn')}
-                className={language === 'vn' ? 'bg-accent' : ''}
+                onClick={() => setLanguage('vi')}
+                className={language === 'vi' ? 'bg-accent' : ''}
               >
                 {t('common.vietnamese')}
               </DropdownMenuItem>

--- a/src/components/branch/BranchForm.tsx
+++ b/src/components/branch/BranchForm.tsx
@@ -49,7 +49,7 @@ const translations = {
     duplicateCode: 'This branch code already exists in the selected organization',
     noOrganizations: 'No active organizations available'
   },
-  vn: {
+  vi: {
     createTitle: 'Tạo Chi Nhánh Mới',
     editTitle: 'Chỉnh Sửa Chi Nhánh',
     createDescription: 'Thêm chi nhánh mới vào tổ chức đã chọn.',

--- a/src/components/branch/BranchManagement.tsx
+++ b/src/components/branch/BranchManagement.tsx
@@ -48,7 +48,7 @@ const translations = {
     deleteError: 'Failed to delete branch',
     loading: 'Loading...'
   },
-  vn: {
+  vi: {
     title: 'Quản Lý Chi Nhánh',
     description: 'Quản lý chi nhánh thuộc các tổ chức cho hoạt động theo địa điểm',
     createNew: 'Tạo Chi Nhánh Mới',

--- a/src/components/goodsreceipt/AssetModelSelectWithSearch.tsx
+++ b/src/components/goodsreceipt/AssetModelSelectWithSearch.tsx
@@ -14,7 +14,7 @@ const translations = {
     noAssetModel: 'No asset model found.',
     assetModels: 'Asset Models'
   },
-  vn: {
+  vi: {
     selectAssetModel: 'Chọn mẫu tài sản',
     searchAssetModel: 'Tìm kiếm mẫu tài sản...',
     noAssetModel: 'Không tìm thấy mẫu tài sản.',

--- a/src/components/goodsreceipt/GoodsReceiptApproval.tsx
+++ b/src/components/goodsreceipt/GoodsReceiptApproval.tsx
@@ -115,7 +115,7 @@ const translations = {
     cancelled: 'Cancelled',
     reversed: 'Reversed'
   },
-  vn: {
+  vi: {
     title: 'Phê Duyệt Phiếu Nhập Kho',
     back: 'Quay Lại Danh Sách',
     receiptNo: 'Số Phiếu',
@@ -279,11 +279,11 @@ export function GoodsReceiptApproval({ receiptId, onBack }: GoodsReceiptApproval
   const canApprove = receipt.status === 'Submitted' && blockingWarnings.length === 0
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleString(language === 'vn' ? 'vi-VN' : 'en-US')
+    return new Date(dateString).toLocaleString(language === 'vi' ? 'vi-VN' : 'en-US')
   }
 
   const formatDateOnly = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString(language === 'vn' ? 'vi-VN' : 'en-US')
+    return new Date(dateString).toLocaleDateString(language === 'vi' ? 'vi-VN' : 'en-US')
   }
 
   const getPartnerOrSource = () => {

--- a/src/components/goodsreceipt/GoodsReceiptForm.tsx
+++ b/src/components/goodsreceipt/GoodsReceiptForm.tsx
@@ -102,7 +102,7 @@ const translations = {
     receiptSaved: 'Receipt saved as draft successfully',
     receiptSubmitted: 'Receipt submitted to receiving successfully'
   },
-  vn: {
+  vi: {
     // Header section
     receiptHeader: 'Thông Tin Phiếu',
     receiptNo: 'Số Phiếu',

--- a/src/components/goodsreceipt/GoodsReceiptFormFixed.tsx
+++ b/src/components/goodsreceipt/GoodsReceiptFormFixed.tsx
@@ -103,7 +103,7 @@ const translations = {
     receiptSaved: 'Receipt saved as draft successfully',
     receiptSubmitted: 'Receipt submitted to receiving successfully'
   },
-  vn: {
+  vi: {
     // Header section
     receiptHeader: 'Thông Tin Phiếu',
     receiptNo: 'Số Phiếu',

--- a/src/components/goodsreceipt/GoodsReceiptFormPage.tsx
+++ b/src/components/goodsreceipt/GoodsReceiptFormPage.tsx
@@ -112,7 +112,7 @@ const translations = {
     validationErrors: 'Please fix the following errors:',
     unsavedChanges: 'You have unsaved changes. Are you sure you want to leave?'
   },
-  vn: {
+  vi: {
     // Navigation
     backToList: 'Quay Lại Danh Sách Phiếu Nhập',
     createReceipt: 'Tạo Phiếu Nhập Kho',

--- a/src/components/goodsreceipt/GoodsReceiptFormUpdated.tsx
+++ b/src/components/goodsreceipt/GoodsReceiptFormUpdated.tsx
@@ -104,7 +104,7 @@ const translations = {
     receiptSaved: 'Receipt saved as draft successfully',
     receiptSubmitted: 'Receipt submitted to receiving successfully'
   },
-  vn: {
+  vi: {
     // Header section
     receiptHeader: 'Thông Tin Phiếu',
     receiptNo: 'Số Phiếu',

--- a/src/components/goodsreceipt/GoodsReceiptFormWrapper.tsx
+++ b/src/components/goodsreceipt/GoodsReceiptFormWrapper.tsx
@@ -18,7 +18,7 @@ const translations = {
     receiptCreated: 'Receipt created successfully',
     unsavedChanges: 'You have unsaved changes. Are you sure you want to leave?'
   },
-  vn: {
+  vi: {
     backToList: 'Quay Lại Danh Sách Phiếu Nhập',
     createReceipt: 'Tạo Phiếu Nhập Kho',
     editReceipt: 'Sửa Phiếu Nhập Kho',

--- a/src/components/goodsreceipt/GoodsReceiptManagement.tsx
+++ b/src/components/goodsreceipt/GoodsReceiptManagement.tsx
@@ -69,7 +69,7 @@ const translations = {
     Return: 'Return',
     Manual: 'Manual Entry'
   },
-  vn: {
+  vi: {
     title: 'Quản Lý Phiếu Nhập Kho',
     description: 'Quản lý phiếu nhập kho, tạo phiếu mới và theo dõi tình trạng nhập hàng',
     create: 'Tạo Phiếu',
@@ -224,7 +224,7 @@ export function GoodsReceiptManagement() {
     setReceipts(prev => prev.filter(r => r.id !== id))
     setDeleteDialogOpen(false)
     setReceiptToDelete(null)
-    toast.success(language === 'vn' ? 'Xóa phiếu thành công' : 'Receipt deleted successfully')
+    toast.success(language === 'vi' ? 'Xóa phiếu thành công' : 'Receipt deleted successfully')
   }
 
   const openDeleteDialog = (receiptId: string) => {
@@ -253,7 +253,7 @@ export function GoodsReceiptManagement() {
   }
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString(language === 'vn' ? 'vi-VN' : 'en-US')
+    return new Date(dateString).toLocaleDateString(language === 'vi' ? 'vi-VN' : 'en-US')
   }
 
   const exportData = () => {
@@ -385,7 +385,7 @@ export function GoodsReceiptManagement() {
                 className="flex-1"
                 placeholder={t.startDate}
               />
-              <span className="text-sm text-muted-foreground">{language === 'vn' ? 'đến' : 'to'}</span>
+              <span className="text-sm text-muted-foreground">{language === 'vi' ? 'đến' : 'to'}</span>
               <Input
                 type="date"
                 value={endDate}

--- a/src/components/goodsreceipt/GoodsReceiptSpecialActions.tsx
+++ b/src/components/goodsreceipt/GoodsReceiptSpecialActions.tsx
@@ -46,7 +46,7 @@ const translations = {
     overReceiptInfo: 'Over receipts are allowed but require verification of additional quantities.',
     splitLineInfo: 'Split lines allow receiving the same model in multiple lots, bins, or entries.'
   },
-  vn: {
+  vi: {
     specialActions: 'Hành Động Đặc Biệt',
     cancel: 'Hủy Phiếu',
     reverse: 'Đảo Ngược Phiếu',

--- a/src/components/goodsreceipt/GoodsReceiptSubmit.tsx
+++ b/src/components/goodsreceipt/GoodsReceiptSubmit.tsx
@@ -79,7 +79,7 @@ const translations = {
     barcode: 'Barcode',
     notes: 'Notes'
   },
-  vn: {
+  vi: {
     title: 'Gửi Phiếu Nhập Chờ Duyệt',
     backToList: 'Về Danh Sách',
     receiptHeader: 'Thông Tin Phiếu',
@@ -255,11 +255,11 @@ export function GoodsReceiptSubmit({ receiptId, onBack }: GoodsReceiptSubmitProp
   const canSubmit = validationResults.every(r => r.type === 'success')
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString(language === 'vn' ? 'vi-VN' : 'en-US')
+    return new Date(dateString).toLocaleDateString(language === 'vi' ? 'vi-VN' : 'en-US')
   }
 
   const formatDateTime = (dateString: string) => {
-    return new Date(dateString).toLocaleString(language === 'vn' ? 'vi-VN' : 'en-US')
+    return new Date(dateString).toLocaleString(language === 'vi' ? 'vi-VN' : 'en-US')
   }
 
   const getPartnerOrSource = () => {
@@ -302,7 +302,7 @@ export function GoodsReceiptSubmit({ receiptId, onBack }: GoodsReceiptSubmitProp
     }
     
     toast.success(
-      language === 'vn' 
+      language === 'vi' 
         ? `Phiếu ${receipt.receipt_no} đã được gửi chờ duyệt thành công` 
         : `Receipt ${receipt.receipt_no} submitted for approval successfully`
     )

--- a/src/components/goodsreceipt/GoodsReceiptView.tsx
+++ b/src/components/goodsreceipt/GoodsReceiptView.tsx
@@ -118,7 +118,7 @@ const translations = {
     yes: 'Yes',
     no: 'No'
   },
-  vn: {
+  vi: {
     // Navigation
     backToList: 'Quay Lại Danh Sách Phiếu Nhập',
     viewReceipt: 'Xem Phiếu Nhập Kho',
@@ -276,11 +276,11 @@ export function GoodsReceiptView({ receiptId }: GoodsReceiptViewProps) {
   }
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleString(language === 'vn' ? 'vi-VN' : 'en-US')
+    return new Date(dateString).toLocaleString(language === 'vi' ? 'vi-VN' : 'en-US')
   }
 
   const formatDateOnly = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString(language === 'vn' ? 'vi-VN' : 'en-US')
+    return new Date(dateString).toLocaleDateString(language === 'vi' ? 'vi-VN' : 'en-US')
   }
 
   const getPartnerOrSource = () => {

--- a/src/components/goodsreceipt/PartnerSelectWithSearch.tsx
+++ b/src/components/goodsreceipt/PartnerSelectWithSearch.tsx
@@ -14,7 +14,7 @@ const translations = {
     noPartner: 'No partner found.',
     partners: 'Partners'
   },
-  vn: {
+  vi: {
     selectPartner: 'Chọn đối tác',
     searchPartner: 'Tìm kiếm đối tác...',
     noPartner: 'Không tìm thấy đối tác.',

--- a/src/components/goodsreceipt/UomSelectWithSearch.tsx
+++ b/src/components/goodsreceipt/UomSelectWithSearch.tsx
@@ -14,7 +14,7 @@ const translations = {
     noUoM: 'No unit of measure found.',
     unitsOfMeasure: 'Units of Measure'
   },
-  vn: {
+  vi: {
     selectUoM: 'Chọn đơn vị tính',
     searchUoM: 'Tìm kiếm đơn vị tính...',
     noUoM: 'Không tìm thấy đơn vị tính.',

--- a/src/components/goodsreceipt/WarehouseSelectWithSearch.tsx
+++ b/src/components/goodsreceipt/WarehouseSelectWithSearch.tsx
@@ -14,7 +14,7 @@ const translations = {
     noWarehouse: 'No warehouse found.',
     warehouses: 'Warehouses'
   },
-  vn: {
+  vi: {
     selectWarehouse: 'Chọn kho',
     searchWarehouse: 'Tìm kiếm kho...',
     noWarehouse: 'Không tìm thấy kho.',

--- a/src/components/lot/LotForm.tsx
+++ b/src/components/lot/LotForm.tsx
@@ -66,7 +66,7 @@ export function LotForm({ lot, isEdit = false, onSave, onCancel, showCard = true
       modelAssetReadonly: 'Model asset cannot be modified',
       receivedDateReadonly: 'Received date cannot be modified'
     },
-    vn: {
+    vi: {
       title: isEdit ? 'Sửa Lot/Lô hàng' : 'Tạo Lot/Lô hàng mới',
       lotCode: 'Mã Lot',
       modelAsset: 'Model Tài sản',

--- a/src/components/lot/LotManagement.tsx
+++ b/src/components/lot/LotManagement.tsx
@@ -107,7 +107,7 @@ export function LotManagement() {
       mfgDate: 'Mfg Date',
       expDate: 'Exp Date'
     },
-    vn: {
+    vi: {
       title: 'Quản lý Lot/Lô hàng',
       createNew: 'Tạo Lot mới',
       search: 'Tìm kiếm theo mã lot...',
@@ -681,7 +681,7 @@ export function LotManagement() {
           <DialogHeader>
             <DialogTitle>{t.createNew}</DialogTitle>
             <DialogDescription>
-              {language === 'vn' ? 'Tạo lot/lô hàng mới cho hệ thống quản lý tồn kho.' : 'Create a new lot/batch for inventory management system.'}
+              {language === 'vi' ? 'Tạo lot/lô hàng mới cho hệ thống quản lý tồn kho.' : 'Create a new lot/batch for inventory management system.'}
             </DialogDescription>
           </DialogHeader>
           <LotForm

--- a/src/components/modelasset/ModelAssetForm.tsx
+++ b/src/components/modelasset/ModelAssetForm.tsx
@@ -72,7 +72,7 @@ export function ModelAssetForm({
       duplicateCode: 'Model code already exists',
       success: isEditing ? 'Model asset updated successfully' : 'Model asset created successfully'
     },
-    vn: {
+    vi: {
       title: isEditing ? 'Sửa Model Asset' : 'Tạo Model Asset',
       modelCode: 'Mã Model Asset',
       modelCodePlaceholder: 'Nhập mã model asset (ví dụ: MD_001)',

--- a/src/components/modelasset/ModelAssetManagement.tsx
+++ b/src/components/modelasset/ModelAssetManagement.tsx
@@ -64,7 +64,7 @@ export function ModelAssetManagement() {
       noResults: 'No model assets found',
       showingResults: 'Showing {count} model assets'
     },
-    vn: {
+    vi: {
       title: 'Quản lý Model Asset',
       description: 'Quản lý Model Assets với phương thức theo dõi và đơn vị tính',
       create: 'Tạo Model Asset',

--- a/src/components/organization/OrganizationForm.tsx
+++ b/src/components/organization/OrganizationForm.tsx
@@ -44,7 +44,7 @@ const translations = {
     invalidCodeFormat: 'Code must follow format XX_999 (e.g., HQ_001)',
     duplicateCode: 'This organization code already exists'
   },
-  vn: {
+  vi: {
     createTitle: 'Tạo Tổ Chức Mới',
     editTitle: 'Chỉnh Sửa Tổ Chức',
     createDescription: 'Thêm tổ chức mới vào hệ thống.',

--- a/src/components/organization/OrganizationManagement.tsx
+++ b/src/components/organization/OrganizationManagement.tsx
@@ -45,7 +45,7 @@ const translations = {
     deleteError: 'Failed to delete organization',
     loading: 'Loading...'
   },
-  vn: {
+  vi: {
     title: 'Quản Lý Tổ Chức',
     description: 'Quản lý tổ chức, thông tin cơ bản và trạng thái',
     createNew: 'Tạo Tổ Chức Mới',

--- a/src/components/partner/PartnerForm.tsx
+++ b/src/components/partner/PartnerForm.tsx
@@ -67,7 +67,7 @@ export function PartnerForm({ isOpen, onClose, onSave, partner, mode }: PartnerF
       createSuccess: 'Partner created successfully',
       updateSuccess: 'Partner updated successfully'
     },
-    vn: {
+    vi: {
       createTitle: 'Tạo Đối Tác Mới',
       editTitle: 'Chỉnh Sửa Đối Tác',
       partnerCode: 'Mã Đối Tác',

--- a/src/components/partner/PartnerManagement.tsx
+++ b/src/components/partner/PartnerManagement.tsx
@@ -48,7 +48,7 @@ export function PartnerManagement() {
       activeSuppliers: 'Active Suppliers',
       activeCustomers: 'Active Customers'
     },
-    vn: {
+    vi: {
       title: 'Quản Lý Đối Tác',
       description: 'Quản lý nhà cung cấp và khách hàng cho hoạt động kho của bạn',
       addPartner: 'Thêm Đối Tác',

--- a/src/components/stockonhand/AssetEditForm.tsx
+++ b/src/components/stockonhand/AssetEditForm.tsx
@@ -65,7 +65,7 @@ export function AssetEditForm({
       locationRequired: 'Location is required when status is In Stock',
       readOnly: 'This field cannot be modified'
     },
-    vn: {
+    vi: {
       title: 'Sửa Asset',
       description: 'Cập nhật vị trí, kho, đối tác và trạng thái asset',
       assetId: 'Mã Asset',

--- a/src/components/stockonhand/AssetForm.tsx
+++ b/src/components/stockonhand/AssetForm.tsx
@@ -73,7 +73,7 @@ export function AssetForm({
       success: 'Assets created successfully',
       locationRequired: 'Location is required when status is In Stock'
     },
-    vn: {
+    vi: {
       title: 'Tạo Asset',
       description: 'Tạo assets mới với số serial duy nhất',
       modelAsset: 'Model Asset',

--- a/src/components/stockonhand/AssetHistoryDialog.tsx
+++ b/src/components/stockonhand/AssetHistoryDialog.tsx
@@ -36,7 +36,7 @@ export function AssetHistoryDialog({
       partnerAssigned: 'Partner Assigned',
       system: 'System'
     },
-    vn: {
+    vi: {
       title: 'Lịch sử Asset',
       description: 'Xem lịch sử thay đổi đầy đủ của asset này',
       action: 'Hành động',

--- a/src/components/stockonhand/AssetManagement.tsx
+++ b/src/components/stockonhand/AssetManagement.tsx
@@ -74,7 +74,7 @@ export function AssetManagement() {
       currentStatus: 'Current status',
       newStatus: 'New status'
     },
-    vn: {
+    vi: {
       title: 'Quản lý Asset (Serial)',
       description: 'Quản lý tài sản cá nhân với số serial duy nhất',
       create: 'Tạo Asset',

--- a/src/components/stockonhand/AssetNoneForm.tsx
+++ b/src/components/stockonhand/AssetNoneForm.tsx
@@ -52,7 +52,7 @@ export function AssetNoneForm({ onSubmit, onCancel, initialData, isSubmitting = 
       },
       note: 'Note: Quantity will be initialized to 0 and managed through inventory movements'
     },
-    vn: {
+    vi: {
       title: 'Form Asset (None)',
       description: 'Tạo bản ghi tồn kho asset không theo dõi',
       modelCode: 'Model Asset',

--- a/src/components/stockonhand/AssetNoneManagement.tsx
+++ b/src/components/stockonhand/AssetNoneManagement.tsx
@@ -81,7 +81,7 @@ export function AssetNoneManagement() {
         createFirst: 'Create your first asset record to get started.'
       }
     },
-    vn: {
+    vi: {
       title: 'Quản lý Asset (None)',
       description: 'Quản lý tồn kho asset theo số lượng bulk',
       addNew: 'Thêm bản ghi mới',

--- a/src/components/stockonhand/StockOnhandManagement.tsx
+++ b/src/components/stockonhand/StockOnhandManagement.tsx
@@ -22,7 +22,7 @@ export function StockOnhandManagement() {
       lotDescription: 'Batch/lot tracking for grouped items',
       noneDescription: 'Bulk quantity tracking without individual identification'
     },
-    vn: {
+    vi: {
       title: 'Tồn kho',
       description: 'Quản lý tồn kho theo phương thức theo dõi',
       serialTab: 'Asset (Serial)',

--- a/src/components/warehouse/GoodsIssueCreatePlaceholder.tsx
+++ b/src/components/warehouse/GoodsIssueCreatePlaceholder.tsx
@@ -92,7 +92,7 @@ const translations = {
       Cancelled: 'Cancelled'
     } as Record<IssueStatus, string>
   },
-  vn: {
+  vi: {
     title: 'Tạo Phiếu Xuất Kho',
     description:
       'Biểu mẫu tạm thời này sẽ gửi sự kiện mô phỏng để màn hình quản lý hiển thị phiếu mới.',

--- a/src/components/warehouse/GoodsIssueManagement.tsx
+++ b/src/components/warehouse/GoodsIssueManagement.tsx
@@ -55,7 +55,7 @@ const translations = {
     remarksLabel: (remarks: string) => `Remarks: ${remarks}`,
     noResults: 'No goods issues found'
   },
-  vn: {
+  vi: {
     title: 'Quản Lý Phiếu Xuất Kho',
     description: 'Theo dõi phiếu xuất kho, tình trạng soạn hàng và độ chính xác thực hiện.',
     create: 'Tạo Phiếu Xuất Kho',

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,12 +1,24 @@
 import React, { createContext, useContext, useState } from 'react'
 
-type Language = 'en' | 'vn'
+type Language = 'en' | 'vi'
 
 interface LanguageContextType {
   language: Language
   currentLanguage: Language
   setLanguage: (language: Language) => void
   t: (key: string, params?: Record<string, string>) => string
+}
+
+const DEFAULT_LANGUAGE: Language = 'en'
+
+const normalizeLanguage = (value: string | null): Language => {
+  if (value === 'vi' || value === 'en') {
+    return value
+  }
+  if (value === 'vn') {
+    return 'vi'
+  }
+  return DEFAULT_LANGUAGE
 }
 
 const translations = {
@@ -127,7 +139,7 @@ const translations = {
     'common.searchBranches': 'Search branches...',
     'common.noResults': 'No results found'
   },
-  vn: {
+  vi: {
     // Navigation
     'nav.dashboards': 'Bảng điều khiển',
     'nav.warehouseOperations': 'Vận hành kho',
@@ -252,10 +264,10 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
   const [language, setLanguage] = useState<Language>(() => {
     // Try to get saved language from localStorage
     if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('language') as Language
-      return saved || 'en'
+      const saved = localStorage.getItem('language')
+      return normalizeLanguage(saved)
     }
-    return 'en'
+    return DEFAULT_LANGUAGE
   })
 
   const t = (key: string, params?: Record<string, string>): string => {


### PR DESCRIPTION
## Summary
- standardize the Vietnamese locale identifier across the language context and translations
- update all components to check for the new `vi` code, including the top bar switcher and downstream forms

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccf22517b88325a41bd6d9dacf2ca3
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Standardizes Vietnamese language code from 'vn' to 'vi' across components and contexts, updating language selection, translation keys, and formatting functions.
> 
>   - **Behavior**:
>     - Standardizes Vietnamese language code from `vn` to `vi` across components like `DebugPanel.tsx`, `TopBar.tsx`, and `LanguageContext.tsx`.
>     - Updates language selection logic in `LanguageContext.tsx` to normalize 'vn' to 'vi'.
>   - **Translations**:
>     - Changes translation keys from `vn` to `vi` in multiple components such as `BranchForm.tsx`, `GoodsReceiptApproval.tsx`, and `PartnerSelectWithSearch.tsx`.
>     - Updates translation usage in `AssetEditForm.tsx`, `GoodsIssueCreatePlaceholder.tsx`, and `OrganizationForm.tsx`.
>   - **Misc**:
>     - Adjusts date formatting logic in `GoodsReceiptApproval.tsx` and `GoodsReceiptSubmit.tsx` to use 'vi-VN' locale.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tringuyen111%2Fproject_tri_inventory&utm_source=github&utm_medium=referral)<sup> for 35624ce15611b9f55958c17bca34e2ec67996b1f. You can [customize](https://app.ellipsis.dev/tringuyen111/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->